### PR TITLE
refactor: replace hardcoded dev domains with env vars

### DIFF
--- a/client/app/cross-modules/identifier/services/project.service.ts
+++ b/client/app/cross-modules/identifier/services/project.service.ts
@@ -1,4 +1,5 @@
 import { serviceInstances } from "@/lib/http-client";
+import { getRuntimeEnv } from "@/lib/runtime-env";
 import {
   CLOUD_BUILD_ENDPOINTS,
   PROJECT_ENDPOINTS,
@@ -33,7 +34,7 @@ export class ProjectService {
     errors: unknown | null;
     isSuccess: boolean;
   }> {
-    const url = `https://dev-logic.blocksdevelopers.com/api/build/repos-list?projectkey=${projectKey}`;
+    const url = `${getRuntimeEnv("BLOCKS_LOGIC_APP_URL")}/api/build/repos-list?projectkey=${projectKey}`;
     return this.logicHttpClient.get(url, undefined, { absoluteUrl: true });
   }
 

--- a/client/app/cross-modules/identifier/services/service-registry.service.ts
+++ b/client/app/cross-modules/identifier/services/service-registry.service.ts
@@ -1,4 +1,5 @@
 import { serviceInstances } from "@/lib/http-client";
+import { getRuntimeEnv } from "@/lib/runtime-env";
 import { SERVICE_REGISTRY_ENDPOINTS } from "@blocks-identifier/constants/endpoint.constant";
 import {
   IGetAllServicesPayload,
@@ -11,7 +12,7 @@ export class ServiceRegistryService {
     payload: IGetAllServicesPayload,
   ): Promise<IGetAllServicesResponse> {
     return this.httpClient.post(
-      "https://dev-logic.blocksdevelopers.com/api/Service/GetAll",
+      `${getRuntimeEnv("BLOCKS_LOGIC_APP_URL")}/api/Service/GetAll`,
       payload,
       undefined,
       { absoluteUrl: true },

--- a/client/app/cross-modules/idp/authentication/services/auth.service.ts
+++ b/client/app/cross-modules/idp/authentication/services/auth.service.ts
@@ -41,7 +41,7 @@ export class AuthService {
     body.append("client_secret", "e048ec1b63d548dd85d053f364d5d54c");
 
     return this.httpClient.post(
-      `https://dev-idp.blocksdevelopers.com${AUTH_ENDPOINTS.TOKEN}`,
+      `${getRuntimeEnv("BLOCKS_IDP_BASE_URL")}${AUTH_ENDPOINTS.TOKEN}`,
       body,
       {
         "Content-Type": "application/x-www-form-urlencoded",

--- a/client/app/cross-modules/idp/iam/services/user.service.ts
+++ b/client/app/cross-modules/idp/iam/services/user.service.ts
@@ -1,11 +1,12 @@
 import { serviceInstances } from "@/lib/http-client";
+import { getRuntimeEnv } from "@/lib/runtime-env";
 import { User } from "@blocks-idp/iam/models/user";
 
 export class UserService {
   private readonly httpClient = serviceInstances.idpService;
   getUser(): Promise<{ data: User }> {
     return this.httpClient.get(
-      "https://dev-idp.blocksdevelopers.com/api/iam/me",
+      `${getRuntimeEnv("BLOCKS_IDP_BASE_URL")}/api/iam/me`,
       undefined,
       { absoluteUrl: true },
     );

--- a/client/app/routes/auth/login.tsx
+++ b/client/app/routes/auth/login.tsx
@@ -187,17 +187,14 @@ export default function LoginPage() {
       setIsStarting(true);
 
       const blocksKey = getRuntimeEnv("BLOCKS_X_BLOCKS_KEY");
-      const baseUrl =
-        getRuntimeEnv("BLOCKS_IDP_BASE_URL") ||
-        "https://dev-idp.blocksdevelopers.com";
+      const baseUrl = getRuntimeEnv("BLOCKS_IDP_BASE_URL");
       const clientId =
         getRuntimeEnv("BLOCKS_OIDC_CLIENT_ID") ||
         "1bd234da-1fa1-4264-982e-3debb1078be5";
-      const redirectUrlBase =
-        getRuntimeEnv("BLOCKS_APP_URL", {
-          stripPort: true,
-          ensureTrailingSlash: true,
-        }) || "https://dev-observability.blocksdevelopers.com/";
+      const redirectUrlBase = getRuntimeEnv("BLOCKS_APP_URL", {
+        stripPort: true,
+        ensureTrailingSlash: true,
+      });
       const redirectUri = `${redirectUrlBase}login/callback`;
       const initiateUrl = `${baseUrl}/api/idp/initiate?x-blocks-key=${blocksKey}&clientId=${clientId}&redirectUri=${redirectUri}`;
       const headers: Record<string, string> = {};

--- a/client/app/routes/dashboard/profile.tsx
+++ b/client/app/routes/dashboard/profile.tsx
@@ -1,4 +1,7 @@
+import { getRuntimeEnv } from "@/lib/runtime-env";
+
 export default function ProfilePage() {
-	window.location.replace("http://dev-idp.blocksdevelopers.com/profile");
+	const idpBaseUrl = getRuntimeEnv("BLOCKS_IDP_BASE_URL");
+	window.location.replace(`${idpBaseUrl}/profile`);
 	return null;
 }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -35,6 +35,7 @@ function resolveDevHttps(): { cert: Buffer; key: Buffer } | undefined {
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, __dirname, "BLOCKS_");
   const proxyTarget = env.BLOCKS_API_BASE_URL;
+  const idpProxyTarget = env.BLOCKS_IDP_BASE_URL;
   const devHost = env.BLOCKS_DEV_HOST || true;
   const httpsConfig = resolveDevHttps();
 
@@ -90,12 +91,16 @@ export default defineConfig(({ mode }) => {
         ".blocksdevelopers.com",
       ],
       proxy: {
-        "/dev-idp-proxy": {
-          target: "https://dev-idp.blocksdevelopers.com",
-          changeOrigin: true,
-          secure: true,
-          rewrite: (path) => path.replace(/^\/dev-idp-proxy/, ""),
-        },
+        ...(idpProxyTarget
+          ? {
+              "/dev-idp-proxy": {
+                target: idpProxyTarget,
+                changeOrigin: true,
+                secure: true,
+                rewrite: (path) => path.replace(/^\/dev-idp-proxy/, ""),
+              },
+            }
+          : {}),
         ...(proxyTarget
           ? {
               "/api": {


### PR DESCRIPTION
## Summary
- Replaced hardcoded `dev-idp.blocksdevelopers.com` and `dev-logic.blocksdevelopers.com` references in client services/routes with `getRuntimeEnv('BLOCKS_IDP_BASE_URL')` / `getRuntimeEnv('BLOCKS_LOGIC_APP_URL')`.
- Gated the `/dev-idp-proxy` block in `vite.config.ts` on `BLOCKS_IDP_BASE_URL` so the same config works across environments.
- Removed dev-domain fallbacks in `login.tsx` (OIDC client ID fallback kept since it is not a domain).

## Test plan
- [ ] `npx tsc -b` passes in `client/`
- [ ] Local dev: ensure `BLOCKS_IDP_BASE_URL` and `BLOCKS_LOGIC_APP_URL` are set in `.env`; login + profile + project/service-registry calls hit the expected origins
- [ ] Stg deploy: confirm runtime env injection (`__BLOCKS_*__`) resolves to stg domains