### PR TITLE
chore: comment out provably dead code (reversible DEADCODE markers)

### DIFF
--- a/client/app/components/common/loader-spinner/loader-spinner.tsx
+++ b/client/app/components/common/loader-spinner/loader-spinner.tsx
@@ -1,37 +1,38 @@
-import React from "react";
-import { Loader } from "lucide-react";
-
-interface LoadingSpinnerProps {
-  size?: number;
-  color?: string;
-  variant?: "fullscreen" | "overlay" | "inline";
-  label?: string;
-}
-
-const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
-  size = 32,
-  color = "text-primary",
-  variant = "overlay",
-  label = "Loading...",
-}) => {
-  const containerClasses = {
-    fullscreen:
-      "fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm",
-    overlay:
-      "absolute inset-0 z-10 flex items-center justify-center bg-background/80 backdrop-blur-sm",
-    inline: "flex items-center justify-center p-4",
-  };
-
-  return (
-    <div className={containerClasses[variant]}>
-      <div className="flex flex-col items-center space-y-4">
-        <div className="flex animate-pulse">
-          <Loader size={size} className={`animate-spin ${color}`} />
-        </div>
-        {label && <p className="text-sm font-medium text-muted-foreground">{label}</p>}
-      </div>
-    </div>
-  );
-};
-
-export default LoadingSpinner;
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import React from "react";
+// import { Loader } from "lucide-react";
+//
+// interface LoadingSpinnerProps {
+//   size?: number;
+//   color?: string;
+//   variant?: "fullscreen" | "overlay" | "inline";
+//   label?: string;
+// }
+//
+// const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
+//   size = 32,
+//   color = "text-primary",
+//   variant = "overlay",
+//   label = "Loading...",
+// }) => {
+//   const containerClasses = {
+//     fullscreen:
+//       "fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm",
+//     overlay:
+//       "absolute inset-0 z-10 flex items-center justify-center bg-background/80 backdrop-blur-sm",
+//     inline: "flex items-center justify-center p-4",
+//   };
+//
+//   return (
+//     <div className={containerClasses[variant]}>
+//       <div className="flex flex-col items-center space-y-4">
+//         <div className="flex animate-pulse">
+//           <Loader size={size} className={`animate-spin ${color}`} />
+//         </div>
+//         {label && <p className="text-sm font-medium text-muted-foreground">{label}</p>}
+//       </div>
+//     </div>
+//   );
+// };
+//
+// export default LoadingSpinner;

--- a/client/app/components/core/calendar/calendar/calendar.tsx
+++ b/client/app/components/core/calendar/calendar/calendar.tsx
@@ -1,57 +1,58 @@
-import * as React from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
-import { DayPicker } from "react-day-picker";
-
-import { cn } from "@/lib/utils";
-import { buttonVariants } from "@/components/core";
-
-export type CalendarProps = React.ComponentProps<typeof DayPicker>;
-
-function Calendar({ className, classNames, showOutsideDays = true, ...props }: CalendarProps) {
-  return (
-    <DayPicker
-      showOutsideDays={showOutsideDays}
-      className={cn("p-3", className)}
-      classNames={{
-        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
-        month: "space-y-4",
-        caption: "flex justify-center pt-1 relative items-center",
-        caption_label: "text-sm font-medium",
-        nav: "space-x-1 flex items-center",
-        nav_button: cn(
-          buttonVariants({ variant: "outline" }),
-          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100",
-        ),
-        nav_button_previous: "absolute left-1",
-        nav_button_next: "absolute right-1",
-        table: "w-full border-collapse space-y-1",
-        head_row: "flex",
-        head_cell: "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
-        row: "flex w-full mt-2",
-        cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
-        day: cn(
-          buttonVariants({ variant: "ghost" }),
-          "h-9 w-9 p-0 font-normal aria-selected:opacity-100",
-        ),
-        day_range_end: "day-range-end",
-        day_selected:
-          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
-        day_today: "bg-accent text-accent-foreground",
-        day_outside:
-          "day-outside text-muted-foreground opacity-50 aria-selected:bg-accent/50 aria-selected:text-muted-foreground aria-selected:opacity-30",
-        day_disabled: "text-muted-foreground opacity-50",
-        day_range_middle: "aria-selected:bg-accent aria-selected:text-accent-foreground",
-        day_hidden: "invisible",
-        ...classNames,
-      }}
-      components={{
-        IconLeft: () => <ChevronLeft className="h-4 w-4" />,
-        IconRight: () => <ChevronRight className="h-4 w-4" />,
-      }}
-      {...props}
-    />
-  );
-}
-Calendar.displayName = "Calendar";
-
-export { Calendar };
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import * as React from "react";
+// import { ChevronLeft, ChevronRight } from "lucide-react";
+// import { DayPicker } from "react-day-picker";
+//
+// import { cn } from "@/lib/utils";
+// import { buttonVariants } from "@/components/core";
+//
+// export type CalendarProps = React.ComponentProps<typeof DayPicker>;
+//
+// function Calendar({ className, classNames, showOutsideDays = true, ...props }: CalendarProps) {
+//   return (
+//     <DayPicker
+//       showOutsideDays={showOutsideDays}
+//       className={cn("p-3", className)}
+//       classNames={{
+//         months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
+//         month: "space-y-4",
+//         caption: "flex justify-center pt-1 relative items-center",
+//         caption_label: "text-sm font-medium",
+//         nav: "space-x-1 flex items-center",
+//         nav_button: cn(
+//           buttonVariants({ variant: "outline" }),
+//           "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100",
+//         ),
+//         nav_button_previous: "absolute left-1",
+//         nav_button_next: "absolute right-1",
+//         table: "w-full border-collapse space-y-1",
+//         head_row: "flex",
+//         head_cell: "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
+//         row: "flex w-full mt-2",
+//         cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+//         day: cn(
+//           buttonVariants({ variant: "ghost" }),
+//           "h-9 w-9 p-0 font-normal aria-selected:opacity-100",
+//         ),
+//         day_range_end: "day-range-end",
+//         day_selected:
+//           "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+//         day_today: "bg-accent text-accent-foreground",
+//         day_outside:
+//           "day-outside text-muted-foreground opacity-50 aria-selected:bg-accent/50 aria-selected:text-muted-foreground aria-selected:opacity-30",
+//         day_disabled: "text-muted-foreground opacity-50",
+//         day_range_middle: "aria-selected:bg-accent aria-selected:text-accent-foreground",
+//         day_hidden: "invisible",
+//         ...classNames,
+//       }}
+//       components={{
+//         IconLeft: () => <ChevronLeft className="h-4 w-4" />,
+//         IconRight: () => <ChevronRight className="h-4 w-4" />,
+//       }}
+//       {...props}
+//     />
+//   );
+// }
+// Calendar.displayName = "Calendar";
+//
+// export { Calendar };

--- a/client/app/components/core/collapsible/collapsible/collapsible.tsx
+++ b/client/app/components/core/collapsible/collapsible/collapsible.tsx
@@ -1,9 +1,10 @@
-import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
-
-const Collapsible = CollapsiblePrimitive.Root;
-
-const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger;
-
-const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent;
-
-export { Collapsible, CollapsibleTrigger, CollapsibleContent };
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
+//
+// const Collapsible = CollapsiblePrimitive.Root;
+//
+// const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger;
+//
+// const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent;
+//
+// export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/client/app/components/core/drawer/drawer/drawer.tsx
+++ b/client/app/components/core/drawer/drawer/drawer.tsx
@@ -1,98 +1,99 @@
-import * as React from "react";
-import { Drawer as DrawerPrimitive } from "vaul";
-
-import { cn } from "@/lib/utils";
-
-const Drawer = ({
-  shouldScaleBackground = true,
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
-  <DrawerPrimitive.Root shouldScaleBackground={shouldScaleBackground} {...props} />
-);
-Drawer.displayName = "Drawer";
-
-const DrawerTrigger = DrawerPrimitive.Trigger;
-
-const DrawerPortal = DrawerPrimitive.Portal;
-
-const DrawerClose = DrawerPrimitive.Close;
-
-const DrawerOverlay = React.forwardRef<
-  React.ElementRef<typeof DrawerPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-  <DrawerPrimitive.Overlay
-    ref={ref}
-    className={cn("fixed inset-0 z-50 bg-black/80", className)}
-    {...props}
-  />
-));
-DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
-
-const DrawerContent = React.forwardRef<
-  React.ElementRef<typeof DrawerPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DrawerPortal>
-    <DrawerOverlay />
-    <DrawerPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
-        className,
-      )}
-      {...props}
-    >
-      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
-      {children}
-    </DrawerPrimitive.Content>
-  </DrawerPortal>
-));
-DrawerContent.displayName = "DrawerContent";
-
-const DrawerHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)} {...props} />
-);
-DrawerHeader.displayName = "DrawerHeader";
-
-const DrawerFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("mt-auto flex flex-col gap-2 p-4", className)} {...props} />
-);
-DrawerFooter.displayName = "DrawerFooter";
-
-const DrawerTitle = React.forwardRef<
-  React.ElementRef<typeof DrawerPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
->(({ className, ...props }, ref) => (
-  <DrawerPrimitive.Title
-    ref={ref}
-    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
-    {...props}
-  />
-));
-DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
-
-const DrawerDescription = React.forwardRef<
-  React.ElementRef<typeof DrawerPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
->(({ className, ...props }, ref) => (
-  <DrawerPrimitive.Description
-    ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
-    {...props}
-  />
-));
-DrawerDescription.displayName = DrawerPrimitive.Description.displayName;
-
-export {
-  Drawer,
-  DrawerPortal,
-  DrawerOverlay,
-  DrawerTrigger,
-  DrawerClose,
-  DrawerContent,
-  DrawerHeader,
-  DrawerFooter,
-  DrawerTitle,
-  DrawerDescription,
-};
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import * as React from "react";
+// import { Drawer as DrawerPrimitive } from "vaul";
+//
+// import { cn } from "@/lib/utils";
+//
+// const Drawer = ({
+//   shouldScaleBackground = true,
+//   ...props
+// }: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
+//   <DrawerPrimitive.Root shouldScaleBackground={shouldScaleBackground} {...props} />
+// );
+// Drawer.displayName = "Drawer";
+//
+// const DrawerTrigger = DrawerPrimitive.Trigger;
+//
+// const DrawerPortal = DrawerPrimitive.Portal;
+//
+// const DrawerClose = DrawerPrimitive.Close;
+//
+// const DrawerOverlay = React.forwardRef<
+//   React.ElementRef<typeof DrawerPrimitive.Overlay>,
+//   React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+// >(({ className, ...props }, ref) => (
+//   <DrawerPrimitive.Overlay
+//     ref={ref}
+//     className={cn("fixed inset-0 z-50 bg-black/80", className)}
+//     {...props}
+//   />
+// ));
+// DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
+//
+// const DrawerContent = React.forwardRef<
+//   React.ElementRef<typeof DrawerPrimitive.Content>,
+//   React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+// >(({ className, children, ...props }, ref) => (
+//   <DrawerPortal>
+//     <DrawerOverlay />
+//     <DrawerPrimitive.Content
+//       ref={ref}
+//       className={cn(
+//         "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+//         className,
+//       )}
+//       {...props}
+//     >
+//       <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+//       {children}
+//     </DrawerPrimitive.Content>
+//   </DrawerPortal>
+// ));
+// DrawerContent.displayName = "DrawerContent";
+//
+// const DrawerHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+//   <div className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)} {...props} />
+// );
+// DrawerHeader.displayName = "DrawerHeader";
+//
+// const DrawerFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+//   <div className={cn("mt-auto flex flex-col gap-2 p-4", className)} {...props} />
+// );
+// DrawerFooter.displayName = "DrawerFooter";
+//
+// const DrawerTitle = React.forwardRef<
+//   React.ElementRef<typeof DrawerPrimitive.Title>,
+//   React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+// >(({ className, ...props }, ref) => (
+//   <DrawerPrimitive.Title
+//     ref={ref}
+//     className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+//     {...props}
+//   />
+// ));
+// DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
+//
+// const DrawerDescription = React.forwardRef<
+//   React.ElementRef<typeof DrawerPrimitive.Description>,
+//   React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+// >(({ className, ...props }, ref) => (
+//   <DrawerPrimitive.Description
+//     ref={ref}
+//     className={cn("text-sm text-muted-foreground", className)}
+//     {...props}
+//   />
+// ));
+// DrawerDescription.displayName = DrawerPrimitive.Description.displayName;
+//
+// export {
+//   Drawer,
+//   DrawerPortal,
+//   DrawerOverlay,
+//   DrawerTrigger,
+//   DrawerClose,
+//   DrawerContent,
+//   DrawerHeader,
+//   DrawerFooter,
+//   DrawerTitle,
+//   DrawerDescription,
+// };

--- a/client/app/components/core/spinner-loader/spinner-loader.tsx
+++ b/client/app/components/core/spinner-loader/spinner-loader.tsx
@@ -1,14 +1,15 @@
-import React from "react";
-
-const SpinnerLoader = () => {
-  return (
-    <div
-      className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-primary border-r-transparent"
-      role="status"
-    >
-      <span className="sr-only">Loading...</span>
-    </div>
-  );
-};
-
-export default SpinnerLoader;
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import React from "react";
+//
+// const SpinnerLoader = () => {
+//   return (
+//     <div
+//       className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-primary border-r-transparent"
+//       role="status"
+//     >
+//       <span className="sr-only">Loading...</span>
+//     </div>
+//   );
+// };
+//
+// export default SpinnerLoader;

--- a/client/app/components/core/stepper/context.tsx
+++ b/client/app/components/core/stepper/context.tsx
@@ -1,78 +1,79 @@
-import * as React from "react";
-import type { StepperProps } from "./types";
-
-interface StepperContextValue extends StepperProps {
-  clickable?: boolean;
-  isError?: boolean;
-  isLoading?: boolean;
-  isVertical?: boolean;
-  stepCount?: number;
-  expandVerticalSteps?: boolean;
-  activeStep: number;
-  initialStep: number;
-}
-
-type StepperContextProviderProps = {
-  value: Omit<StepperContextValue, "activeStep">;
-  children: React.ReactNode;
-};
-
-const StepperContext = React.createContext<
-  StepperContextValue & {
-    nextStep: () => void;
-    prevStep: () => void;
-    resetSteps: () => void;
-    // eslint-disable-next-line
-    setStep: (step: number) => void;
-  }
->({
-  steps: [],
-  activeStep: 0,
-  initialStep: 0,
-  nextStep: () => {},
-  prevStep: () => {},
-  resetSteps: () => {},
-  setStep: () => {},
-});
-
-const StepperProvider = ({ value, children }: StepperContextProviderProps) => {
-  const isError = value.state === "error";
-  const isLoading = value.state === "loading";
-
-  const [activeStep, setActiveStep] = React.useState(value.initialStep);
-
-  const nextStep = () => {
-    setActiveStep((prev) => prev + 1);
-  };
-
-  const prevStep = () => {
-    setActiveStep((prev) => prev - 1);
-  };
-
-  const resetSteps = () => {
-    setActiveStep(value.initialStep);
-  };
-
-  const setStep = (step: number) => {
-    setActiveStep(step);
-  };
-
-  return (
-    <StepperContext.Provider
-      value={{
-        ...value,
-        isError,
-        isLoading,
-        activeStep,
-        nextStep,
-        prevStep,
-        resetSteps,
-        setStep,
-      }}
-    >
-      {children}
-    </StepperContext.Provider>
-  );
-};
-
-export { StepperContext, StepperProvider };
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import * as React from "react";
+// import type { StepperProps } from "./types";
+//
+// interface StepperContextValue extends StepperProps {
+//   clickable?: boolean;
+//   isError?: boolean;
+//   isLoading?: boolean;
+//   isVertical?: boolean;
+//   stepCount?: number;
+//   expandVerticalSteps?: boolean;
+//   activeStep: number;
+//   initialStep: number;
+// }
+//
+// type StepperContextProviderProps = {
+//   value: Omit<StepperContextValue, "activeStep">;
+//   children: React.ReactNode;
+// };
+//
+// const StepperContext = React.createContext<
+//   StepperContextValue & {
+//     nextStep: () => void;
+//     prevStep: () => void;
+//     resetSteps: () => void;
+//     // eslint-disable-next-line
+//     setStep: (step: number) => void;
+//   }
+// >({
+//   steps: [],
+//   activeStep: 0,
+//   initialStep: 0,
+//   nextStep: () => {},
+//   prevStep: () => {},
+//   resetSteps: () => {},
+//   setStep: () => {},
+// });
+//
+// const StepperProvider = ({ value, children }: StepperContextProviderProps) => {
+//   const isError = value.state === "error";
+//   const isLoading = value.state === "loading";
+//
+//   const [activeStep, setActiveStep] = React.useState(value.initialStep);
+//
+//   const nextStep = () => {
+//     setActiveStep((prev) => prev + 1);
+//   };
+//
+//   const prevStep = () => {
+//     setActiveStep((prev) => prev - 1);
+//   };
+//
+//   const resetSteps = () => {
+//     setActiveStep(value.initialStep);
+//   };
+//
+//   const setStep = (step: number) => {
+//     setActiveStep(step);
+//   };
+//
+//   return (
+//     <StepperContext.Provider
+//       value={{
+//         ...value,
+//         isError,
+//         isLoading,
+//         activeStep,
+//         nextStep,
+//         prevStep,
+//         resetSteps,
+//         setStep,
+//       }}
+//     >
+//       {children}
+//     </StepperContext.Provider>
+//   );
+// };
+//
+// export { StepperContext, StepperProvider };

--- a/client/app/components/core/stepper/horizontal-step.tsx
+++ b/client/app/components/core/stepper/horizontal-step.tsx
@@ -1,109 +1,110 @@
-import { cn } from "@/lib/utils";
-import * as React from "react";
-import { StepButtonContainer } from "./step-button-container";
-import { StepIcon } from "./step-icon";
-import { StepLabel } from "./step-label";
-import type { StepSharedProps } from "./types";
-import { useStepper } from "./use-stepper";
-
-const HorizontalStep = React.forwardRef<HTMLDivElement, StepSharedProps>((props, ref) => {
-  const {
-    isError,
-    isLoading,
-    onClickStep,
-    variant,
-    clickable,
-    checkIcon: checkIconContext,
-    errorIcon: errorIconContext,
-    styles,
-    steps,
-    setStep,
-  } = useStepper();
-
-  const {
-    index,
-    isCompletedStep,
-    isCurrentStep,
-    hasVisited,
-    icon,
-    label,
-    description,
-    isKeepError,
-    state,
-    checkIcon: checkIconProp,
-    errorIcon: errorIconProp,
-  } = props;
-
-  const localIsLoading = isLoading || state === "loading";
-  const localIsError = isError || state === "error";
-
-  const opacity = hasVisited ? 1 : 0.5;
-
-  const active = variant === "line" ? isCompletedStep || isCurrentStep : isCompletedStep;
-
-  const checkIcon = checkIconProp || checkIconContext;
-  const errorIcon = errorIconProp || errorIconContext;
-
-  return (
-    <div
-      aria-disabled={!hasVisited}
-      className={cn(
-        "stepper__horizontal-step",
-        "flex items-center relative transition-all duration-200",
-        "[&:not(:last-child)]:flex-1",
-        "[&:not(:last-child)]:after:transition-all [&:not(:last-child)]:after:duration-200",
-        "[&:not(:last-child)]:after:content-[''] [&:not(:last-child)]:after:h-[2px] [&:not(:last-child)]:after:bg-border",
-        "data-[completed=true]:[&:not(:last-child)]:after:bg-primary",
-        "data-[invalid=true]:[&:not(:last-child)]:after:bg-destructive",
-        variant === "circle-alt" &&
-          "justify-start flex-col flex-1 [&:not(:last-child)]:after:relative [&:not(:last-child)]:after:order-[-1] [&:not(:last-child)]:after:start-[50%] [&:not(:last-child)]:after:end-[50%] [&:not(:last-child)]:after:top-[calc(var(--step-icon-size)/2)] [&:not(:last-child)]:after:w-[calc((100%-var(--step-icon-size))-(var(--step-gap)))]",
-        variant === "circle" &&
-          "[&:not(:last-child)]:after:flex-1 [&:not(:last-child)]:after:ms-[var(--step-gap)] [&:not(:last-child)]:after:me-[var(--step-gap)]",
-        variant === "line" && "flex-col flex-1 border-t-[3px] data-[active=true]:border-primary",
-        styles?.["horizontal-step"],
-      )}
-      data-optional={steps[index || 0]?.optional}
-      data-completed={isCompletedStep}
-      data-active={active}
-      data-invalid={localIsError}
-      data-clickable={clickable}
-      onClick={() => onClickStep?.(index || 0, setStep)}
-      ref={ref}
-    >
-      <div
-        className={cn(
-          "stepper__horizontal-step-container",
-          "flex items-center",
-          variant === "circle-alt" && "flex-col justify-center gap-1",
-          variant === "line" && "w-full",
-          styles?.["horizontal-step-container"],
-        )}
-      >
-        <StepButtonContainer {...{ ...props, isError: localIsError, isLoading: localIsLoading }}>
-          <StepIcon
-            {...{
-              index,
-              isCompletedStep,
-              isCurrentStep,
-              isError: localIsError,
-              isKeepError,
-              isLoading: localIsLoading,
-            }}
-            icon={icon}
-            checkIcon={checkIcon}
-            errorIcon={errorIcon}
-          />
-        </StepButtonContainer>
-        <StepLabel
-          label={label}
-          description={description}
-
-          {...{ isCurrentStep, opacity }}
-        />
-      </div>
-    </div>
-  );
-});
-
-HorizontalStep.displayName = "HorizontalStep";
-export { HorizontalStep };
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import { cn } from "@/lib/utils";
+// import * as React from "react";
+// import { StepButtonContainer } from "./step-button-container";
+// import { StepIcon } from "./step-icon";
+// import { StepLabel } from "./step-label";
+// import type { StepSharedProps } from "./types";
+// import { useStepper } from "./use-stepper";
+//
+// const HorizontalStep = React.forwardRef<HTMLDivElement, StepSharedProps>((props, ref) => {
+//   const {
+//     isError,
+//     isLoading,
+//     onClickStep,
+//     variant,
+//     clickable,
+//     checkIcon: checkIconContext,
+//     errorIcon: errorIconContext,
+//     styles,
+//     steps,
+//     setStep,
+//   } = useStepper();
+//
+//   const {
+//     index,
+//     isCompletedStep,
+//     isCurrentStep,
+//     hasVisited,
+//     icon,
+//     label,
+//     description,
+//     isKeepError,
+//     state,
+//     checkIcon: checkIconProp,
+//     errorIcon: errorIconProp,
+//   } = props;
+//
+//   const localIsLoading = isLoading || state === "loading";
+//   const localIsError = isError || state === "error";
+//
+//   const opacity = hasVisited ? 1 : 0.5;
+//
+//   const active = variant === "line" ? isCompletedStep || isCurrentStep : isCompletedStep;
+//
+//   const checkIcon = checkIconProp || checkIconContext;
+//   const errorIcon = errorIconProp || errorIconContext;
+//
+//   return (
+//     <div
+//       aria-disabled={!hasVisited}
+//       className={cn(
+//         "stepper__horizontal-step",
+//         "flex items-center relative transition-all duration-200",
+//         "[&:not(:last-child)]:flex-1",
+//         "[&:not(:last-child)]:after:transition-all [&:not(:last-child)]:after:duration-200",
+//         "[&:not(:last-child)]:after:content-[''] [&:not(:last-child)]:after:h-[2px] [&:not(:last-child)]:after:bg-border",
+//         "data-[completed=true]:[&:not(:last-child)]:after:bg-primary",
+//         "data-[invalid=true]:[&:not(:last-child)]:after:bg-destructive",
+//         variant === "circle-alt" &&
+//           "justify-start flex-col flex-1 [&:not(:last-child)]:after:relative [&:not(:last-child)]:after:order-[-1] [&:not(:last-child)]:after:start-[50%] [&:not(:last-child)]:after:end-[50%] [&:not(:last-child)]:after:top-[calc(var(--step-icon-size)/2)] [&:not(:last-child)]:after:w-[calc((100%-var(--step-icon-size))-(var(--step-gap)))]",
+//         variant === "circle" &&
+//           "[&:not(:last-child)]:after:flex-1 [&:not(:last-child)]:after:ms-[var(--step-gap)] [&:not(:last-child)]:after:me-[var(--step-gap)]",
+//         variant === "line" && "flex-col flex-1 border-t-[3px] data-[active=true]:border-primary",
+//         styles?.["horizontal-step"],
+//       )}
+//       data-optional={steps[index || 0]?.optional}
+//       data-completed={isCompletedStep}
+//       data-active={active}
+//       data-invalid={localIsError}
+//       data-clickable={clickable}
+//       onClick={() => onClickStep?.(index || 0, setStep)}
+//       ref={ref}
+//     >
+//       <div
+//         className={cn(
+//           "stepper__horizontal-step-container",
+//           "flex items-center",
+//           variant === "circle-alt" && "flex-col justify-center gap-1",
+//           variant === "line" && "w-full",
+//           styles?.["horizontal-step-container"],
+//         )}
+//       >
+//         <StepButtonContainer {...{ ...props, isError: localIsError, isLoading: localIsLoading }}>
+//           <StepIcon
+//             {...{
+//               index,
+//               isCompletedStep,
+//               isCurrentStep,
+//               isError: localIsError,
+//               isKeepError,
+//               isLoading: localIsLoading,
+//             }}
+//             icon={icon}
+//             checkIcon={checkIcon}
+//             errorIcon={errorIcon}
+//           />
+//         </StepButtonContainer>
+//         <StepLabel
+//           label={label}
+//           description={description}
+//
+//           {...{ isCurrentStep, opacity }}
+//         />
+//       </div>
+//     </div>
+//   );
+// });
+//
+// HorizontalStep.displayName = "HorizontalStep";
+// export { HorizontalStep };

--- a/client/app/components/core/stepper/index.tsx
+++ b/client/app/components/core/stepper/index.tsx
@@ -1,166 +1,167 @@
-import { cn } from "@/lib/utils";
-import * as React from "react";
-import { StepperProvider } from "./context";
-import { Step } from "./step";
-import type { StepItem, StepProps, StepperProps } from "./types";
-import { useMediaQuery } from "./use-media-query";
-import { useStepper } from "./use-stepper";
-
-const VARIABLE_SIZES = {
-  sm: "36px",
-  md: "40px",
-  lg: "44px",
-};
-
-const Stepper = React.forwardRef<HTMLDivElement, StepperProps>(
-  (props, ref: React.Ref<HTMLDivElement>) => {
-    const {
-      className,
-      children,
-      orientation: orientationProp = "horizontal",
-      state,
-      responsive = true,
-      checkIcon,
-      errorIcon,
-      onClickStep,
-      mobileBreakpoint,
-      expandVerticalSteps = false,
-      initialStep = 0,
-      size = "md",
-      steps,
-      variant,
-      styles,
-      variables,
-      scrollTracking = false,
-      ...rest
-    } = props;
-
-    const childArr = React.Children.toArray(children);
-
-    const items = [] as React.ReactElement[];
-
-    const footer = childArr.map((child) => {
-      if (!React.isValidElement(child)) {
-        throw new Error("Stepper children must be valid React elements.");
-      }
-      if (child.type === Step) {
-        items.push(child);
-        return null;
-      }
-
-      return child;
-    });
-
-    const stepCount = items.length;
-
-    const isMobile = useMediaQuery(`(max-width: ${mobileBreakpoint || "768px"})`);
-
-    const clickable = !!onClickStep;
-
-    const orientation = isMobile && responsive ? "vertical" : orientationProp;
-
-    const isVertical = orientation === "vertical";
-
-    return (
-      <StepperProvider
-        value={{
-          initialStep,
-          orientation,
-          state,
-          size,
-          responsive,
-          checkIcon,
-          errorIcon,
-          onClickStep,
-          clickable,
-          stepCount,
-          isVertical,
-          variant: variant || "circle",
-          expandVerticalSteps,
-          steps,
-          scrollTracking,
-          styles,
-        }}
-      >
-        <div
-          ref={ref}
-          className={cn(
-            "stepper__main-container",
-            "flex w-full flex-wrap",
-            stepCount === 1 ? "justify-end" : "justify-between",
-            orientation === "vertical" ? "flex-col" : "flex-row",
-            variant === "line" && orientation === "horizontal" && "gap-4",
-            className,
-            styles?.["main-container"],
-          )}
-          style={
-            {
-              "--step-icon-size":
-                variables?.["--step-icon-size"] || `${VARIABLE_SIZES[size || "md"]}`,
-              "--step-gap": variables?.["--step-gap"] || "8px",
-            } as React.CSSProperties
-          }
-          {...rest}
-        >
-          <VerticalContent>{items}</VerticalContent>
-        </div>
-        {orientation === "horizontal" && <HorizontalContent>{items}</HorizontalContent>}
-        {footer}
-      </StepperProvider>
-    );
-  },
-);
-
-Stepper.displayName = "Stepper";
-const VerticalContent = ({ children }: { children: React.ReactNode }) => {
-  const { activeStep } = useStepper();
-
-  const childArr = React.Children.toArray(children);
-  const stepCount = childArr.length;
-
-  return (
-    <>
-      {React.Children.map(children, (child, i) => {
-        const isCompletedStep =
-          (React.isValidElement<StepProps>(child) && child.props.isCompletedStep) ?? i < activeStep;
-        const isLastStep = i === stepCount - 1;
-        const isCurrentStep = i === activeStep;
-
-        const stepProps = {
-          index: i,
-          isCompletedStep,
-          isCurrentStep,
-          isLastStep,
-        };
-
-        if (React.isValidElement<StepProps>(child)) {
-          return React.cloneElement(child, stepProps);
-        }
-        return null;
-      })}
-    </>
-  );
-};
-
-const HorizontalContent = ({ children }: { children: React.ReactNode }) => {
-  const { activeStep } = useStepper();
-  const childArr = React.Children.toArray(children);
-
-  if (activeStep > childArr.length) {
-    return null;
-  }
-
-  return (
-    <>
-      {React.Children.map(childArr[activeStep], (node) => {
-        if (!React.isValidElement<{ children?: React.ReactNode }>(node)) {
-          return null;
-        }
-        return React.Children.map(node.props.children, (childNode) => childNode);
-      })}
-    </>
-  );
-};
-
-export { Stepper, Step, useStepper };
-export type { StepProps, StepperProps, StepItem };
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import { cn } from "@/lib/utils";
+// import * as React from "react";
+// import { StepperProvider } from "./context";
+// import { Step } from "./step";
+// import type { StepItem, StepProps, StepperProps } from "./types";
+// import { useMediaQuery } from "./use-media-query";
+// import { useStepper } from "./use-stepper";
+//
+// const VARIABLE_SIZES = {
+//   sm: "36px",
+//   md: "40px",
+//   lg: "44px",
+// };
+//
+// const Stepper = React.forwardRef<HTMLDivElement, StepperProps>(
+//   (props, ref: React.Ref<HTMLDivElement>) => {
+//     const {
+//       className,
+//       children,
+//       orientation: orientationProp = "horizontal",
+//       state,
+//       responsive = true,
+//       checkIcon,
+//       errorIcon,
+//       onClickStep,
+//       mobileBreakpoint,
+//       expandVerticalSteps = false,
+//       initialStep = 0,
+//       size = "md",
+//       steps,
+//       variant,
+//       styles,
+//       variables,
+//       scrollTracking = false,
+//       ...rest
+//     } = props;
+//
+//     const childArr = React.Children.toArray(children);
+//
+//     const items = [] as React.ReactElement[];
+//
+//     const footer = childArr.map((child) => {
+//       if (!React.isValidElement(child)) {
+//         throw new Error("Stepper children must be valid React elements.");
+//       }
+//       if (child.type === Step) {
+//         items.push(child);
+//         return null;
+//       }
+//
+//       return child;
+//     });
+//
+//     const stepCount = items.length;
+//
+//     const isMobile = useMediaQuery(`(max-width: ${mobileBreakpoint || "768px"})`);
+//
+//     const clickable = !!onClickStep;
+//
+//     const orientation = isMobile && responsive ? "vertical" : orientationProp;
+//
+//     const isVertical = orientation === "vertical";
+//
+//     return (
+//       <StepperProvider
+//         value={{
+//           initialStep,
+//           orientation,
+//           state,
+//           size,
+//           responsive,
+//           checkIcon,
+//           errorIcon,
+//           onClickStep,
+//           clickable,
+//           stepCount,
+//           isVertical,
+//           variant: variant || "circle",
+//           expandVerticalSteps,
+//           steps,
+//           scrollTracking,
+//           styles,
+//         }}
+//       >
+//         <div
+//           ref={ref}
+//           className={cn(
+//             "stepper__main-container",
+//             "flex w-full flex-wrap",
+//             stepCount === 1 ? "justify-end" : "justify-between",
+//             orientation === "vertical" ? "flex-col" : "flex-row",
+//             variant === "line" && orientation === "horizontal" && "gap-4",
+//             className,
+//             styles?.["main-container"],
+//           )}
+//           style={
+//             {
+//               "--step-icon-size":
+//                 variables?.["--step-icon-size"] || `${VARIABLE_SIZES[size || "md"]}`,
+//               "--step-gap": variables?.["--step-gap"] || "8px",
+//             } as React.CSSProperties
+//           }
+//           {...rest}
+//         >
+//           <VerticalContent>{items}</VerticalContent>
+//         </div>
+//         {orientation === "horizontal" && <HorizontalContent>{items}</HorizontalContent>}
+//         {footer}
+//       </StepperProvider>
+//     );
+//   },
+// );
+//
+// Stepper.displayName = "Stepper";
+// const VerticalContent = ({ children }: { children: React.ReactNode }) => {
+//   const { activeStep } = useStepper();
+//
+//   const childArr = React.Children.toArray(children);
+//   const stepCount = childArr.length;
+//
+//   return (
+//     <>
+//       {React.Children.map(children, (child, i) => {
+//         const isCompletedStep =
+//           (React.isValidElement<StepProps>(child) && child.props.isCompletedStep) ?? i < activeStep;
+//         const isLastStep = i === stepCount - 1;
+//         const isCurrentStep = i === activeStep;
+//
+//         const stepProps = {
+//           index: i,
+//           isCompletedStep,
+//           isCurrentStep,
+//           isLastStep,
+//         };
+//
+//         if (React.isValidElement<StepProps>(child)) {
+//           return React.cloneElement(child, stepProps);
+//         }
+//         return null;
+//       })}
+//     </>
+//   );
+// };
+//
+// const HorizontalContent = ({ children }: { children: React.ReactNode }) => {
+//   const { activeStep } = useStepper();
+//   const childArr = React.Children.toArray(children);
+//
+//   if (activeStep > childArr.length) {
+//     return null;
+//   }
+//
+//   return (
+//     <>
+//       {React.Children.map(childArr[activeStep], (node) => {
+//         if (!React.isValidElement<{ children?: React.ReactNode }>(node)) {
+//           return null;
+//         }
+//         return React.Children.map(node.props.children, (childNode) => childNode);
+//       })}
+//     </>
+//   );
+// };
+//
+// export { Stepper, Step, useStepper };
+// export type { StepProps, StepperProps, StepItem };

--- a/client/app/components/core/stepper/step-button-container.tsx
+++ b/client/app/components/core/stepper/step-button-container.tsx
@@ -1,58 +1,59 @@
-import * as React from "react";
-
-import { Button } from "@/components/core";
-import { cn } from "@/lib/utils";
-import type { StepSharedProps } from "./types";
-import { useStepper } from "./use-stepper";
-
-type StepButtonContainerProps = StepSharedProps & {
-  children?: React.ReactNode;
-};
-
-const StepButtonContainer = ({
-  isCurrentStep,
-  isCompletedStep,
-  children,
-  isError,
-  isLoading: isLoadingProp,
-  onClickStep,
-}: StepButtonContainerProps) => {
-  const { clickable, isLoading: isLoadingContext, variant, styles } = useStepper();
-
-  const currentStepClickable = clickable || !!onClickStep;
-
-  const isLoading = isLoadingProp || isLoadingContext;
-
-  if (variant === "line") {
-    return null;
-  }
-
-  return (
-    <Button
-      variant="ghost"
-      type="button"
-      tabIndex={currentStepClickable ? 0 : -1}
-      className={cn(
-        "stepper__step-button-container",
-        "pointer-events-none rounded-full p-0",
-        "h-[var(--step-icon-size)] w-[var(--step-icon-size)]",
-        "flex items-center justify-center rounded-full border-2",
-        "data-[clickable=true]:pointer-events-auto",
-        "data-[active=true]:border-primary data-[active=true]:bg-primary data-[active=true]:text-primary-foreground",
-        "data-[current=true]:border-primary data-[current=true]:bg-secondary",
-        "data-[invalid=true]:border-destructive data-[invalid=true]:bg-destructive data-[invalid=true]:text-destructive-foreground",
-        styles?.["step-button-container"],
-      )}
-      aria-current={isCurrentStep ? "step" : undefined}
-      data-current={isCurrentStep}
-      data-invalid={isError && (isCurrentStep || isCompletedStep)}
-      data-active={isCompletedStep}
-      data-clickable={currentStepClickable}
-      data-loading={isLoading && (isCurrentStep || isCompletedStep)}
-    >
-      {children}
-    </Button>
-  );
-};
-
-export { StepButtonContainer };
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import * as React from "react";
+//
+// import { Button } from "@/components/core";
+// import { cn } from "@/lib/utils";
+// import type { StepSharedProps } from "./types";
+// import { useStepper } from "./use-stepper";
+//
+// type StepButtonContainerProps = StepSharedProps & {
+//   children?: React.ReactNode;
+// };
+//
+// const StepButtonContainer = ({
+//   isCurrentStep,
+//   isCompletedStep,
+//   children,
+//   isError,
+//   isLoading: isLoadingProp,
+//   onClickStep,
+// }: StepButtonContainerProps) => {
+//   const { clickable, isLoading: isLoadingContext, variant, styles } = useStepper();
+//
+//   const currentStepClickable = clickable || !!onClickStep;
+//
+//   const isLoading = isLoadingProp || isLoadingContext;
+//
+//   if (variant === "line") {
+//     return null;
+//   }
+//
+//   return (
+//     <Button
+//       variant="ghost"
+//       type="button"
+//       tabIndex={currentStepClickable ? 0 : -1}
+//       className={cn(
+//         "stepper__step-button-container",
+//         "pointer-events-none rounded-full p-0",
+//         "h-[var(--step-icon-size)] w-[var(--step-icon-size)]",
+//         "flex items-center justify-center rounded-full border-2",
+//         "data-[clickable=true]:pointer-events-auto",
+//         "data-[active=true]:border-primary data-[active=true]:bg-primary data-[active=true]:text-primary-foreground",
+//         "data-[current=true]:border-primary data-[current=true]:bg-secondary",
+//         "data-[invalid=true]:border-destructive data-[invalid=true]:bg-destructive data-[invalid=true]:text-destructive-foreground",
+//         styles?.["step-button-container"],
+//       )}
+//       aria-current={isCurrentStep ? "step" : undefined}
+//       data-current={isCurrentStep}
+//       data-invalid={isError && (isCurrentStep || isCompletedStep)}
+//       data-active={isCompletedStep}
+//       data-clickable={currentStepClickable}
+//       data-loading={isLoading && (isCurrentStep || isCompletedStep)}
+//     >
+//       {children}
+//     </Button>
+//   );
+// };
+//
+// export { StepButtonContainer };

--- a/client/app/components/core/stepper/step-icon.tsx
+++ b/client/app/components/core/stepper/step-icon.tsx
@@ -1,123 +1,124 @@
-import { cn } from "@/lib/utils";
-import { cva } from "class-variance-authority";
-import { CheckIcon, Loader2, X } from "lucide-react";
-import * as React from "react";
-import type { IconType } from "./types";
-import { useStepper } from "./use-stepper";
-
-interface StepIconProps {
-  isCompletedStep?: boolean;
-  isCurrentStep?: boolean;
-  isError?: boolean;
-  isLoading?: boolean;
-  isKeepError?: boolean;
-  icon?: IconType;
-  index?: number;
-  checkIcon?: IconType;
-  errorIcon?: IconType;
-}
-
-const iconVariants = cva("", {
-  variants: {
-    size: {
-      sm: "size-4",
-      md: "size-4",
-      lg: "size-5",
-    },
-  },
-  defaultVariants: {
-    size: "md",
-  },
-});
-
-const StepIcon = React.forwardRef<HTMLDivElement, StepIconProps>((props, ref) => {
-  const { size } = useStepper();
-
-  const {
-    isCompletedStep,
-    isCurrentStep,
-    isError,
-    isLoading,
-    isKeepError,
-    icon: CustomIcon,
-    index,
-    checkIcon: CustomCheckIcon,
-    errorIcon: CustomErrorIcon,
-  } = props;
-
-  const Icon = React.useMemo(() => (CustomIcon ? CustomIcon : null), [CustomIcon]);
-
-  const ErrorIcon = React.useMemo(
-    () => (CustomErrorIcon ? CustomErrorIcon : null),
-    [CustomErrorIcon],
-  );
-
-  const Check = React.useMemo(
-    () => (CustomCheckIcon ? CustomCheckIcon : CheckIcon),
-    [CustomCheckIcon],
-  );
-
-  return React.useMemo(() => {
-    if (isCompletedStep) {
-      if (isError && isKeepError) {
-        return (
-          <div key="icon">
-            <X className={cn(iconVariants({ size }))} />
-          </div>
-        );
-      }
-      return (
-        <div key="check-icon">
-          <Check className={cn(iconVariants({ size }))} />
-        </div>
-      );
-    }
-    if (isCurrentStep) {
-      if (isError && ErrorIcon) {
-        return (
-          <div key="error-icon">
-            <ErrorIcon className={cn(iconVariants({ size }))} />
-          </div>
-        );
-      }
-      if (isError) {
-        return (
-          <div key="icon">
-            <X className={cn(iconVariants({ size }))} />
-          </div>
-        );
-      }
-      if (isLoading) {
-        return <Loader2 className={cn(iconVariants({ size }), "animate-spin")} />;
-      }
-    }
-    if (Icon) {
-      return (
-        <div key="step-icon">
-          <Icon className={cn(iconVariants({ size }))} />
-        </div>
-      );
-    }
-    return (
-      <span ref={ref} key="label" className={cn("font-medium text-center text-md")}>
-        {(index || 0) + 1}
-      </span>
-    );
-  }, [
-    isCompletedStep,
-    isCurrentStep,
-    isError,
-    isLoading,
-    Icon,
-    index,
-    Check,
-    ErrorIcon,
-    isKeepError,
-    ref,
-    size,
-  ]);
-});
-
-StepIcon.displayName = "StepIcon";
-
-export { StepIcon };
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import { cn } from "@/lib/utils";
+// import { cva } from "class-variance-authority";
+// import { CheckIcon, Loader2, X } from "lucide-react";
+// import * as React from "react";
+// import type { IconType } from "./types";
+// import { useStepper } from "./use-stepper";
+//
+// interface StepIconProps {
+//   isCompletedStep?: boolean;
+//   isCurrentStep?: boolean;
+//   isError?: boolean;
+//   isLoading?: boolean;
+//   isKeepError?: boolean;
+//   icon?: IconType;
+//   index?: number;
+//   checkIcon?: IconType;
+//   errorIcon?: IconType;
+// }
+//
+// const iconVariants = cva("", {
+//   variants: {
+//     size: {
+//       sm: "size-4",
+//       md: "size-4",
+//       lg: "size-5",
+//     },
+//   },
+//   defaultVariants: {
+//     size: "md",
+//   },
+// });
+//
+// const StepIcon = React.forwardRef<HTMLDivElement, StepIconProps>((props, ref) => {
+//   const { size } = useStepper();
+//
+//   const {
+//     isCompletedStep,
+//     isCurrentStep,
+//     isError,
+//     isLoading,
+//     isKeepError,
+//     icon: CustomIcon,
+//     index,
+//     checkIcon: CustomCheckIcon,
+//     errorIcon: CustomErrorIcon,
+//   } = props;
+//
+//   const Icon = React.useMemo(() => (CustomIcon ? CustomIcon : null), [CustomIcon]);
+//
+//   const ErrorIcon = React.useMemo(
+//     () => (CustomErrorIcon ? CustomErrorIcon : null),
+//     [CustomErrorIcon],
+//   );
+//
+//   const Check = React.useMemo(
+//     () => (CustomCheckIcon ? CustomCheckIcon : CheckIcon),
+//     [CustomCheckIcon],
+//   );
+//
+//   return React.useMemo(() => {
+//     if (isCompletedStep) {
+//       if (isError && isKeepError) {
+//         return (
+//           <div key="icon">
+//             <X className={cn(iconVariants({ size }))} />
+//           </div>
+//         );
+//       }
+//       return (
+//         <div key="check-icon">
+//           <Check className={cn(iconVariants({ size }))} />
+//         </div>
+//       );
+//     }
+//     if (isCurrentStep) {
+//       if (isError && ErrorIcon) {
+//         return (
+//           <div key="error-icon">
+//             <ErrorIcon className={cn(iconVariants({ size }))} />
+//           </div>
+//         );
+//       }
+//       if (isError) {
+//         return (
+//           <div key="icon">
+//             <X className={cn(iconVariants({ size }))} />
+//           </div>
+//         );
+//       }
+//       if (isLoading) {
+//         return <Loader2 className={cn(iconVariants({ size }), "animate-spin")} />;
+//       }
+//     }
+//     if (Icon) {
+//       return (
+//         <div key="step-icon">
+//           <Icon className={cn(iconVariants({ size }))} />
+//         </div>
+//       );
+//     }
+//     return (
+//       <span ref={ref} key="label" className={cn("font-medium text-center text-md")}>
+//         {(index || 0) + 1}
+//       </span>
+//     );
+//   }, [
+//     isCompletedStep,
+//     isCurrentStep,
+//     isError,
+//     isLoading,
+//     Icon,
+//     index,
+//     Check,
+//     ErrorIcon,
+//     isKeepError,
+//     ref,
+//     size,
+//   ]);
+// });
+//
+// StepIcon.displayName = "StepIcon";
+//
+// export { StepIcon };

--- a/client/app/components/core/stepper/step-label.tsx
+++ b/client/app/components/core/stepper/step-label.tsx
@@ -1,82 +1,83 @@
-import { cn } from "@/lib/utils";
-import { cva } from "class-variance-authority";
-import { useStepper } from "./use-stepper";
-import React from "react";
-
-interface StepLabelProps {
-  isCurrentStep?: boolean;
-  opacity: number;
-  label?: string | React.ReactNode;
-  description?: string | null;
-}
-
-const labelVariants = cva("", {
-  variants: {
-    size: {
-      sm: "text-sm",
-      md: "text-sm",
-      lg: "text-base",
-    },
-  },
-  defaultVariants: {
-    size: "md",
-  },
-});
-
-const descriptionVariants = cva("", {
-  variants: {
-    size: {
-      sm: "text-xs",
-      md: "text-xs",
-      lg: "text-sm",
-    },
-  },
-  defaultVariants: {
-    size: "md",
-  },
-});
-
-const StepLabel = ({ isCurrentStep, opacity, label, description }: StepLabelProps) => {
-  const { variant, styles, size, orientation } = useStepper();
-  const shouldRender = !!label || !!description;
-
-  return shouldRender ? (
-    <div
-      aria-current={isCurrentStep ? "step" : undefined}
-      className={cn(
-        "stepper__step-label-container",
-        "flex-col flex",
-        variant !== "line" ? "ms-2" : orientation === "horizontal" && "my-2",
-        variant === "circle-alt" && "text-center",
-        variant === "circle-alt" && orientation === "horizontal" && "ms-0",
-        variant === "circle-alt" && orientation === "vertical" && "text-start",
-        styles?.["step-label-container"],
-      )}
-      style={{
-        opacity,
-      }}
-    >
-      {!!label && (
-        <span
-          className={cn("stepper__step-label", labelVariants({ size }), styles?.["step-label"])}
-        >
-          {label}
-        </span>
-      )}
-      {!!description && (
-        <span
-          className={cn(
-            "stepper__step-description",
-            "text-muted-foreground",
-            descriptionVariants({ size }),
-            styles?.["step-description"],
-          )}
-        >
-          {description}
-        </span>
-      )}
-    </div>
-  ) : null;
-};
-
-export { StepLabel };
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import { cn } from "@/lib/utils";
+// import { cva } from "class-variance-authority";
+// import { useStepper } from "./use-stepper";
+// import React from "react";
+//
+// interface StepLabelProps {
+//   isCurrentStep?: boolean;
+//   opacity: number;
+//   label?: string | React.ReactNode;
+//   description?: string | null;
+// }
+//
+// const labelVariants = cva("", {
+//   variants: {
+//     size: {
+//       sm: "text-sm",
+//       md: "text-sm",
+//       lg: "text-base",
+//     },
+//   },
+//   defaultVariants: {
+//     size: "md",
+//   },
+// });
+//
+// const descriptionVariants = cva("", {
+//   variants: {
+//     size: {
+//       sm: "text-xs",
+//       md: "text-xs",
+//       lg: "text-sm",
+//     },
+//   },
+//   defaultVariants: {
+//     size: "md",
+//   },
+// });
+//
+// const StepLabel = ({ isCurrentStep, opacity, label, description }: StepLabelProps) => {
+//   const { variant, styles, size, orientation } = useStepper();
+//   const shouldRender = !!label || !!description;
+//
+//   return shouldRender ? (
+//     <div
+//       aria-current={isCurrentStep ? "step" : undefined}
+//       className={cn(
+//         "stepper__step-label-container",
+//         "flex-col flex",
+//         variant !== "line" ? "ms-2" : orientation === "horizontal" && "my-2",
+//         variant === "circle-alt" && "text-center",
+//         variant === "circle-alt" && orientation === "horizontal" && "ms-0",
+//         variant === "circle-alt" && orientation === "vertical" && "text-start",
+//         styles?.["step-label-container"],
+//       )}
+//       style={{
+//         opacity,
+//       }}
+//     >
+//       {!!label && (
+//         <span
+//           className={cn("stepper__step-label", labelVariants({ size }), styles?.["step-label"])}
+//         >
+//           {label}
+//         </span>
+//       )}
+//       {!!description && (
+//         <span
+//           className={cn(
+//             "stepper__step-description",
+//             "text-muted-foreground",
+//             descriptionVariants({ size }),
+//             styles?.["step-description"],
+//           )}
+//         >
+//           {description}
+//         </span>
+//       )}
+//     </div>
+//   ) : null;
+// };
+//
+// export { StepLabel };

--- a/client/app/components/core/stepper/step.tsx
+++ b/client/app/components/core/stepper/step.tsx
@@ -1,76 +1,77 @@
-import * as React from "react";
-import { HorizontalStep } from "./horizontal-step";
-import type { StepProps } from "./types";
-import { useStepper } from "./use-stepper";
-import { VerticalStep } from "./vertical-step";
-
-// Props which shouldn't be passed to to the Step component from the user
-interface StepInternalConfig {
-  index: number;
-  isCompletedStep?: boolean;
-  isCurrentStep?: boolean;
-  isLastStep?: boolean;
-}
-
-interface FullStepProps extends StepProps, StepInternalConfig {}
-
-const Step = React.forwardRef<HTMLLIElement, StepProps>(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (props, ref: React.Ref<any>) => {
-    const {
-      children,
-      description,
-      icon,
-      state,
-      checkIcon,
-      errorIcon,
-      index,
-      isCompletedStep,
-      isCurrentStep,
-      isLastStep,
-      isKeepError,
-      label,
-      onClickStep,
-    } = props as FullStepProps;
-
-    const { isVertical, isError, isLoading, clickable } = useStepper();
-
-    const hasVisited = isCurrentStep || isCompletedStep;
-
-    const sharedProps = {
-      isLastStep,
-      isCompletedStep,
-      isCurrentStep,
-      index,
-      isError,
-      isLoading,
-      clickable,
-      label,
-      description,
-      hasVisited,
-      icon,
-      isKeepError,
-      checkIcon,
-      state,
-      errorIcon,
-      onClickStep,
-    };
-
-    const renderStep = () => {
-      switch (isVertical) {
-        case true:
-          return (
-            <VerticalStep ref={ref} {...sharedProps}>
-              {children}
-            </VerticalStep>
-          );
-        default:
-          return <HorizontalStep ref={ref} {...sharedProps} />;
-      }
-    };
-
-    return renderStep();
-  },
-);
-Step.displayName = "Step";
-export { Step };
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import * as React from "react";
+// import { HorizontalStep } from "./horizontal-step";
+// import type { StepProps } from "./types";
+// import { useStepper } from "./use-stepper";
+// import { VerticalStep } from "./vertical-step";
+//
+// // Props which shouldn't be passed to to the Step component from the user
+// interface StepInternalConfig {
+//   index: number;
+//   isCompletedStep?: boolean;
+//   isCurrentStep?: boolean;
+//   isLastStep?: boolean;
+// }
+//
+// interface FullStepProps extends StepProps, StepInternalConfig {}
+//
+// const Step = React.forwardRef<HTMLLIElement, StepProps>(
+//   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+//   (props, ref: React.Ref<any>) => {
+//     const {
+//       children,
+//       description,
+//       icon,
+//       state,
+//       checkIcon,
+//       errorIcon,
+//       index,
+//       isCompletedStep,
+//       isCurrentStep,
+//       isLastStep,
+//       isKeepError,
+//       label,
+//       onClickStep,
+//     } = props as FullStepProps;
+//
+//     const { isVertical, isError, isLoading, clickable } = useStepper();
+//
+//     const hasVisited = isCurrentStep || isCompletedStep;
+//
+//     const sharedProps = {
+//       isLastStep,
+//       isCompletedStep,
+//       isCurrentStep,
+//       index,
+//       isError,
+//       isLoading,
+//       clickable,
+//       label,
+//       description,
+//       hasVisited,
+//       icon,
+//       isKeepError,
+//       checkIcon,
+//       state,
+//       errorIcon,
+//       onClickStep,
+//     };
+//
+//     const renderStep = () => {
+//       switch (isVertical) {
+//         case true:
+//           return (
+//             <VerticalStep ref={ref} {...sharedProps}>
+//               {children}
+//             </VerticalStep>
+//           );
+//         default:
+//           return <HorizontalStep ref={ref} {...sharedProps} />;
+//       }
+//     };
+//
+//     return renderStep();
+//   },
+// );
+// Step.displayName = "Step";
+// export { Step };

--- a/client/app/components/core/stepper/types.ts
+++ b/client/app/components/core/stepper/types.ts
@@ -1,84 +1,85 @@
-import type { LucideIcon } from "lucide-react";
-import React from "react";
-
-type IconType = LucideIcon | React.ComponentType<unknown> | undefined;
-
-type StepItem = {
-  id?: string;
-  label?: string;
-  description?: string;
-  icon?: IconType;
-  optional?: boolean;
-};
-
-interface StepOptions {
-  orientation?: "vertical" | "horizontal";
-  state?: "loading" | "error";
-  responsive?: boolean;
-  checkIcon?: IconType;
-  errorIcon?: IconType;
-  // eslint-disable-next-line
-  onClickStep?: (step: number, setStep: (step: number) => void) => void;
-  mobileBreakpoint?: string;
-  variant?: "circle" | "circle-alt" | "line";
-  expandVerticalSteps?: boolean;
-  size?: "sm" | "md" | "lg";
-  styles?: {
-    /** Styles for the main container */
-    "main-container"?: string;
-    /** Styles for the horizontal step */
-    "horizontal-step"?: string;
-    /** Styles for the horizontal step container (button and labels) */
-    "horizontal-step-container"?: string;
-    /** Styles for the vertical step */
-    "vertical-step"?: string;
-    /** Styles for the vertical step container (button and labels) */
-    "vertical-step-container"?: string;
-    /** Styles for the vertical step content */
-    "vertical-step-content"?: string;
-    /** Styles for the step button container */
-    "step-button-container"?: string;
-    /** Styles for the label and description container */
-    "step-label-container"?: string;
-    /** Styles for the step label */
-    "step-label"?: string;
-    /** Styles for the step description */
-    "step-description"?: string;
-  };
-  variables?: {
-    "--step-icon-size"?: string;
-    "--step-gap"?: string;
-  };
-  scrollTracking?: boolean;
-}
-
-interface StepperProps extends StepOptions {
-  children?: React.ReactNode;
-  className?: string;
-  initialStep: number;
-  steps: StepItem[];
-}
-
-interface StepProps extends React.HTMLAttributes<HTMLLIElement> {
-  label?: string | React.ReactNode;
-  description?: string;
-  icon?: IconType;
-  state?: "loading" | "error";
-  checkIcon?: IconType;
-  errorIcon?: IconType;
-  isCompletedStep?: boolean;
-  isKeepError?: boolean;
-  // eslint-disable-next-line
-  onClickStep?: (step: number, setStep: (step: number) => void) => void;
-}
-
-interface StepSharedProps extends StepProps {
-  isLastStep?: boolean;
-  isCurrentStep?: boolean;
-  index?: number;
-  hasVisited: boolean | undefined;
-  isError?: boolean;
-  isLoading?: boolean;
-}
-
-export type { IconType, StepItem, StepOptions, StepperProps, StepProps, StepSharedProps };
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import type { LucideIcon } from "lucide-react";
+// import React from "react";
+//
+// type IconType = LucideIcon | React.ComponentType<unknown> | undefined;
+//
+// type StepItem = {
+//   id?: string;
+//   label?: string;
+//   description?: string;
+//   icon?: IconType;
+//   optional?: boolean;
+// };
+//
+// interface StepOptions {
+//   orientation?: "vertical" | "horizontal";
+//   state?: "loading" | "error";
+//   responsive?: boolean;
+//   checkIcon?: IconType;
+//   errorIcon?: IconType;
+//   // eslint-disable-next-line
+//   onClickStep?: (step: number, setStep: (step: number) => void) => void;
+//   mobileBreakpoint?: string;
+//   variant?: "circle" | "circle-alt" | "line";
+//   expandVerticalSteps?: boolean;
+//   size?: "sm" | "md" | "lg";
+//   styles?: {
+//     /** Styles for the main container */
+//     "main-container"?: string;
+//     /** Styles for the horizontal step */
+//     "horizontal-step"?: string;
+//     /** Styles for the horizontal step container (button and labels) */
+//     "horizontal-step-container"?: string;
+//     /** Styles for the vertical step */
+//     "vertical-step"?: string;
+//     /** Styles for the vertical step container (button and labels) */
+//     "vertical-step-container"?: string;
+//     /** Styles for the vertical step content */
+//     "vertical-step-content"?: string;
+//     /** Styles for the step button container */
+//     "step-button-container"?: string;
+//     /** Styles for the label and description container */
+//     "step-label-container"?: string;
+//     /** Styles for the step label */
+//     "step-label"?: string;
+//     /** Styles for the step description */
+//     "step-description"?: string;
+//   };
+//   variables?: {
+//     "--step-icon-size"?: string;
+//     "--step-gap"?: string;
+//   };
+//   scrollTracking?: boolean;
+// }
+//
+// interface StepperProps extends StepOptions {
+//   children?: React.ReactNode;
+//   className?: string;
+//   initialStep: number;
+//   steps: StepItem[];
+// }
+//
+// interface StepProps extends React.HTMLAttributes<HTMLLIElement> {
+//   label?: string | React.ReactNode;
+//   description?: string;
+//   icon?: IconType;
+//   state?: "loading" | "error";
+//   checkIcon?: IconType;
+//   errorIcon?: IconType;
+//   isCompletedStep?: boolean;
+//   isKeepError?: boolean;
+//   // eslint-disable-next-line
+//   onClickStep?: (step: number, setStep: (step: number) => void) => void;
+// }
+//
+// interface StepSharedProps extends StepProps {
+//   isLastStep?: boolean;
+//   isCurrentStep?: boolean;
+//   index?: number;
+//   hasVisited: boolean | undefined;
+//   isError?: boolean;
+//   isLoading?: boolean;
+// }
+//
+// export type { IconType, StepItem, StepOptions, StepperProps, StepProps, StepSharedProps };

--- a/client/app/components/core/stepper/use-media-query.tsx
+++ b/client/app/components/core/stepper/use-media-query.tsx
@@ -1,18 +1,19 @@
-import * as React from "react";
-
-export function useMediaQuery(query: string) {
-  const subscribe = React.useCallback(
-    (onStoreChange: () => void) => {
-      const result = matchMedia(query);
-      result.addEventListener("change", onStoreChange);
-      return () => result.removeEventListener("change", onStoreChange);
-    },
-    [query],
-  );
-
-  return React.useSyncExternalStore(
-    subscribe,
-    () => matchMedia(query).matches,
-    () => false,
-  );
-}
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import * as React from "react";
+//
+// export function useMediaQuery(query: string) {
+//   const subscribe = React.useCallback(
+//     (onStoreChange: () => void) => {
+//       const result = matchMedia(query);
+//       result.addEventListener("change", onStoreChange);
+//       return () => result.removeEventListener("change", onStoreChange);
+//     },
+//     [query],
+//   );
+//
+//   return React.useSyncExternalStore(
+//     subscribe,
+//     () => matchMedia(query).matches,
+//     () => false,
+//   );
+// }

--- a/client/app/components/core/stepper/use-stepper.ts
+++ b/client/app/components/core/stepper/use-stepper.ts
@@ -1,45 +1,46 @@
-import * as React from "react";
-import { StepperContext } from "./context";
-
-function usePrevious<T>(value: T): T | undefined {
-  const [state, setState] = React.useState<{ current: T; previous: T | undefined }>({
-    current: value,
-    previous: undefined,
-  });
-
-  if (state.current !== value) {
-    setState({ current: value, previous: state.current });
-  }
-
-  return state.previous;
-}
-
-export function useStepper() {
-  const context = React.useContext(StepperContext);
-
-  if (context === undefined) {
-    throw new Error("useStepper must be used within a StepperProvider");
-  }
-
-  const { ...rest } = context;
-
-  const isLastStep = context.activeStep === context.steps.length - 1;
-  const hasCompletedAllSteps = context.activeStep === context.steps.length;
-
-  const previousActiveStep = usePrevious(context.activeStep);
-
-  const currentStep = context.steps[context.activeStep];
-  const isOptionalStep = !!currentStep?.optional;
-
-  const isDisabledStep = context.activeStep === 0;
-
-  return {
-    ...rest,
-    isLastStep,
-    hasCompletedAllSteps,
-    isOptionalStep,
-    isDisabledStep,
-    currentStep,
-    previousActiveStep,
-  };
-}
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import * as React from "react";
+// import { StepperContext } from "./context";
+//
+// function usePrevious<T>(value: T): T | undefined {
+//   const [state, setState] = React.useState<{ current: T; previous: T | undefined }>({
+//     current: value,
+//     previous: undefined,
+//   });
+//
+//   if (state.current !== value) {
+//     setState({ current: value, previous: state.current });
+//   }
+//
+//   return state.previous;
+// }
+//
+// export function useStepper() {
+//   const context = React.useContext(StepperContext);
+//
+//   if (context === undefined) {
+//     throw new Error("useStepper must be used within a StepperProvider");
+//   }
+//
+//   const { ...rest } = context;
+//
+//   const isLastStep = context.activeStep === context.steps.length - 1;
+//   const hasCompletedAllSteps = context.activeStep === context.steps.length;
+//
+//   const previousActiveStep = usePrevious(context.activeStep);
+//
+//   const currentStep = context.steps[context.activeStep];
+//   const isOptionalStep = !!currentStep?.optional;
+//
+//   const isDisabledStep = context.activeStep === 0;
+//
+//   return {
+//     ...rest,
+//     isLastStep,
+//     hasCompletedAllSteps,
+//     isOptionalStep,
+//     isDisabledStep,
+//     currentStep,
+//     previousActiveStep,
+//   };
+// }

--- a/client/app/components/core/stepper/vertical-step.tsx
+++ b/client/app/components/core/stepper/vertical-step.tsx
@@ -1,175 +1,176 @@
-import { Collapsible, CollapsibleContent } from "@/components/core";
-import { cn } from "@/lib/utils";
-import { cva } from "class-variance-authority";
-import * as React from "react";
-import { StepButtonContainer } from "./step-button-container";
-import { StepIcon } from "./step-icon";
-import { StepLabel } from "./step-label";
-import type { StepSharedProps } from "./types";
-import { useStepper } from "./use-stepper";
-
-type VerticalStepProps = StepSharedProps & {
-  children?: React.ReactNode;
-};
-
-const verticalStepVariants = cva(
-  [
-    "flex flex-col relative transition-all duration-200",
-    "data-[completed=true]:[&:not(:last-child)]:after:bg-primary",
-    "data-[invalid=true]:[&:not(:last-child)]:after:bg-destructive",
-  ],
-  {
-    variants: {
-      variant: {
-        circle: cn(
-          "[&:not(:last-child)]:pb-[var(--step-gap)] [&:not(:last-child)]:gap-[var(--step-gap)]",
-          "[&:not(:last-child)]:after:content-[''] [&:not(:last-child)]:after:w-[2px] [&:not(:last-child)]:after:bg-border",
-          "[&:not(:last-child)]:after:inset-x-[calc(var(--step-icon-size)/2)]",
-          "[&:not(:last-child)]:after:absolute",
-          "[&:not(:last-child)]:after:top-[calc(var(--step-icon-size)+var(--step-gap))]",
-          "[&:not(:last-child)]:after:bottom-[var(--step-gap)]",
-          "[&:not(:last-child)]:after:transition-all [&:not(:last-child)]:after:duration-200",
-        ),
-        line: "flex-1 border-t-0 mb-4",
-      },
-    },
-  },
-);
-
-const VerticalStep = React.forwardRef<HTMLDivElement, VerticalStepProps>((props, ref) => {
-  const {
-    children,
-    index,
-    isCompletedStep,
-    isCurrentStep,
-    label,
-    description,
-    icon,
-    hasVisited,
-    state,
-    checkIcon: checkIconProp,
-    errorIcon: errorIconProp,
-    onClickStep,
-  } = props;
-
-  const {
-    checkIcon: checkIconContext,
-    errorIcon: errorIconContext,
-    isError,
-    isLoading,
-    variant,
-    onClickStep: onClickStepGeneral,
-    clickable,
-    expandVerticalSteps,
-    styles,
-    scrollTracking,
-    orientation,
-    steps,
-    setStep,
-    isLastStep: isLastStepCurrentStep,
-    previousActiveStep,
-  } = useStepper();
-
-  const opacity = hasVisited ? 1 : 0.8;
-  const localIsLoading = isLoading || state === "loading";
-  const localIsError = isError || state === "error";
-
-  const isLastStep = index === steps.length - 1;
-
-  const active = variant === "line" ? isCompletedStep || isCurrentStep : isCompletedStep;
-  const checkIcon = checkIconProp || checkIconContext;
-  const errorIcon = errorIconProp || errorIconContext;
-
-  const renderChildren = () => {
-    if (!expandVerticalSteps) {
-      return (
-        <Collapsible open={isCurrentStep}>
-          <CollapsibleContent
-            ref={(node) => {
-              if (
-                // If the step is the first step and the previous step
-                // was the last step or if the step is not the first step
-                // This prevents initial scrolling when the stepper
-                // is located anywhere other than the top of the view.
-                scrollTracking &&
-                ((index === 0 && previousActiveStep && previousActiveStep === steps.length) ||
-                  (index && index > 0))
-              ) {
-                node?.scrollIntoView({
-                  behavior: "smooth",
-                  block: "center",
-                });
-              }
-            }}
-            className="data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up overflow-hidden"
-          >
-            {children}
-          </CollapsibleContent>
-        </Collapsible>
-      );
-    }
-    return children;
-  };
-
-  return (
-    <div
-      ref={ref}
-      className={cn(
-        "stepper__vertical-step",
-        verticalStepVariants({
-          variant: variant?.includes("circle") ? "circle" : "line",
-        }),
-        isLastStepCurrentStep && "gap-[var(--step-gap)]",
-        styles?.["vertical-step"],
-      )}
-      data-optional={steps[index || 0]?.optional}
-      data-completed={isCompletedStep}
-      data-active={active}
-      data-clickable={clickable || !!onClickStep}
-      data-invalid={localIsError}
-      onClick={() =>
-        onClickStep?.(index || 0, setStep) || onClickStepGeneral?.(index || 0, setStep)
-      }
-    >
-      <div
-        data-vertical={true}
-        data-active={active}
-        className={cn(
-          "stepper__vertical-step-container",
-          "flex items-center",
-          variant === "line" && "border-s-[3px] py-2 ps-3 data-[active=true]:border-primary",
-          styles?.["vertical-step-container"],
-        )}
-      >
-        <StepButtonContainer {...{ isLoading: localIsLoading, isError: localIsError, ...props }}>
-          <StepIcon
-            {...{
-              index,
-              isError: localIsError,
-              isLoading: localIsLoading,
-              isCurrentStep,
-              isCompletedStep,
-            }}
-            icon={icon}
-            checkIcon={checkIcon}
-            errorIcon={errorIcon}
-          />
-        </StepButtonContainer>
-        <StepLabel label={label} description={description} {...{ isCurrentStep, opacity }} />
-      </div>
-      <div
-        className={cn(
-          "stepper__vertical-step-content",
-          !isLastStep && "min-h-4",
-          variant !== "line" && "ps-[--step-icon-size]",
-          variant === "line" && orientation === "vertical" && "min-h-0",
-          styles?.["vertical-step-content"],
-        )}
-      >
-        {renderChildren()}
-      </div>
-    </div>
-  );
-});
-VerticalStep.displayName = "VerticalStep";
-export { VerticalStep };
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import { Collapsible, CollapsibleContent } from "@/components/core";
+// import { cn } from "@/lib/utils";
+// import { cva } from "class-variance-authority";
+// import * as React from "react";
+// import { StepButtonContainer } from "./step-button-container";
+// import { StepIcon } from "./step-icon";
+// import { StepLabel } from "./step-label";
+// import type { StepSharedProps } from "./types";
+// import { useStepper } from "./use-stepper";
+//
+// type VerticalStepProps = StepSharedProps & {
+//   children?: React.ReactNode;
+// };
+//
+// const verticalStepVariants = cva(
+//   [
+//     "flex flex-col relative transition-all duration-200",
+//     "data-[completed=true]:[&:not(:last-child)]:after:bg-primary",
+//     "data-[invalid=true]:[&:not(:last-child)]:after:bg-destructive",
+//   ],
+//   {
+//     variants: {
+//       variant: {
+//         circle: cn(
+//           "[&:not(:last-child)]:pb-[var(--step-gap)] [&:not(:last-child)]:gap-[var(--step-gap)]",
+//           "[&:not(:last-child)]:after:content-[''] [&:not(:last-child)]:after:w-[2px] [&:not(:last-child)]:after:bg-border",
+//           "[&:not(:last-child)]:after:inset-x-[calc(var(--step-icon-size)/2)]",
+//           "[&:not(:last-child)]:after:absolute",
+//           "[&:not(:last-child)]:after:top-[calc(var(--step-icon-size)+var(--step-gap))]",
+//           "[&:not(:last-child)]:after:bottom-[var(--step-gap)]",
+//           "[&:not(:last-child)]:after:transition-all [&:not(:last-child)]:after:duration-200",
+//         ),
+//         line: "flex-1 border-t-0 mb-4",
+//       },
+//     },
+//   },
+// );
+//
+// const VerticalStep = React.forwardRef<HTMLDivElement, VerticalStepProps>((props, ref) => {
+//   const {
+//     children,
+//     index,
+//     isCompletedStep,
+//     isCurrentStep,
+//     label,
+//     description,
+//     icon,
+//     hasVisited,
+//     state,
+//     checkIcon: checkIconProp,
+//     errorIcon: errorIconProp,
+//     onClickStep,
+//   } = props;
+//
+//   const {
+//     checkIcon: checkIconContext,
+//     errorIcon: errorIconContext,
+//     isError,
+//     isLoading,
+//     variant,
+//     onClickStep: onClickStepGeneral,
+//     clickable,
+//     expandVerticalSteps,
+//     styles,
+//     scrollTracking,
+//     orientation,
+//     steps,
+//     setStep,
+//     isLastStep: isLastStepCurrentStep,
+//     previousActiveStep,
+//   } = useStepper();
+//
+//   const opacity = hasVisited ? 1 : 0.8;
+//   const localIsLoading = isLoading || state === "loading";
+//   const localIsError = isError || state === "error";
+//
+//   const isLastStep = index === steps.length - 1;
+//
+//   const active = variant === "line" ? isCompletedStep || isCurrentStep : isCompletedStep;
+//   const checkIcon = checkIconProp || checkIconContext;
+//   const errorIcon = errorIconProp || errorIconContext;
+//
+//   const renderChildren = () => {
+//     if (!expandVerticalSteps) {
+//       return (
+//         <Collapsible open={isCurrentStep}>
+//           <CollapsibleContent
+//             ref={(node) => {
+//               if (
+//                 // If the step is the first step and the previous step
+//                 // was the last step or if the step is not the first step
+//                 // This prevents initial scrolling when the stepper
+//                 // is located anywhere other than the top of the view.
+//                 scrollTracking &&
+//                 ((index === 0 && previousActiveStep && previousActiveStep === steps.length) ||
+//                   (index && index > 0))
+//               ) {
+//                 node?.scrollIntoView({
+//                   behavior: "smooth",
+//                   block: "center",
+//                 });
+//               }
+//             }}
+//             className="data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up overflow-hidden"
+//           >
+//             {children}
+//           </CollapsibleContent>
+//         </Collapsible>
+//       );
+//     }
+//     return children;
+//   };
+//
+//   return (
+//     <div
+//       ref={ref}
+//       className={cn(
+//         "stepper__vertical-step",
+//         verticalStepVariants({
+//           variant: variant?.includes("circle") ? "circle" : "line",
+//         }),
+//         isLastStepCurrentStep && "gap-[var(--step-gap)]",
+//         styles?.["vertical-step"],
+//       )}
+//       data-optional={steps[index || 0]?.optional}
+//       data-completed={isCompletedStep}
+//       data-active={active}
+//       data-clickable={clickable || !!onClickStep}
+//       data-invalid={localIsError}
+//       onClick={() =>
+//         onClickStep?.(index || 0, setStep) || onClickStepGeneral?.(index || 0, setStep)
+//       }
+//     >
+//       <div
+//         data-vertical={true}
+//         data-active={active}
+//         className={cn(
+//           "stepper__vertical-step-container",
+//           "flex items-center",
+//           variant === "line" && "border-s-[3px] py-2 ps-3 data-[active=true]:border-primary",
+//           styles?.["vertical-step-container"],
+//         )}
+//       >
+//         <StepButtonContainer {...{ isLoading: localIsLoading, isError: localIsError, ...props }}>
+//           <StepIcon
+//             {...{
+//               index,
+//               isError: localIsError,
+//               isLoading: localIsLoading,
+//               isCurrentStep,
+//               isCompletedStep,
+//             }}
+//             icon={icon}
+//             checkIcon={checkIcon}
+//             errorIcon={errorIcon}
+//           />
+//         </StepButtonContainer>
+//         <StepLabel label={label} description={description} {...{ isCurrentStep, opacity }} />
+//       </div>
+//       <div
+//         className={cn(
+//           "stepper__vertical-step-content",
+//           !isLastStep && "min-h-4",
+//           variant !== "line" && "ps-[--step-icon-size]",
+//           variant === "line" && orientation === "vertical" && "min-h-0",
+//           styles?.["vertical-step-content"],
+//         )}
+//       >
+//         {renderChildren()}
+//       </div>
+//     </div>
+//   );
+// });
+// VerticalStep.displayName = "VerticalStep";
+// export { VerticalStep };

--- a/client/app/components/module/alert/alerts-filter-toolbar.tsx
+++ b/client/app/components/module/alert/alerts-filter-toolbar.tsx
@@ -1,53 +1,54 @@
-import { FilterToolbar } from "@seliseblocks/genesis-os/components";
-import { type AlertFilter, useAlertFilterQueryParams } from "./use-alert-filter-query-params";
-
-type AlertFilterToolBarProps = {
-  repositories: { value: string; label: string }[];
-};
-
-export function AlertsFilterToolbar({ repositories }: AlertFilterToolBarProps) {
-  const { queryParams, setQueryParams } = useAlertFilterQueryParams();
-
-  const changeHandler = (key: string, value: unknown) => {
-    setQueryParams((params) => ({
-      ...params,
-      [key]: value,
-      page: 0,
-    }));
-  };
-  const resetHandler = () => setQueryParams(null);
-
-  return (
-    <FilterToolbar<AlertFilter>
-      filters={[
-        { key: "search", type: "SearchInput", label: "" },
-        {
-          key: "repositories",
-          type: "MultiSelect",
-          label: "Repositories",
-          props: { options: repositories },
-        },
-      ]}
-      values={{
-        tab: queryParams.tab,
-        search: queryParams.search,
-        repositories: queryParams.repositories,
-        pageIndex: queryParams.page,
-        pageSize: queryParams.pageSize,
-        property: queryParams.sortProperty,
-        isDescending: queryParams.isDescending,
-      }}
-      defaultValues={{
-        tab: "all",
-        search: "",
-        repositories: [],
-        pageIndex: 0,
-        pageSize: 10,
-        property: "name",
-        isDescending: false,
-      }}
-      onChange={changeHandler}
-      onReset={resetHandler}
-    />
-  );
-}
+// DEADCODE 2026-07-29: unreachable from main.tsx/router tree; whole file commented pending review
+// import { FilterToolbar } from "@seliseblocks/genesis-os/components";
+// import { type AlertFilter, useAlertFilterQueryParams } from "./use-alert-filter-query-params";
+//
+// type AlertFilterToolBarProps = {
+//   repositories: { value: string; label: string }[];
+// };
+//
+// export function AlertsFilterToolbar({ repositories }: AlertFilterToolBarProps) {
+//   const { queryParams, setQueryParams } = useAlertFilterQueryParams();
+//
+//   const changeHandler = (key: string, value: unknown) => {
+//     setQueryParams((params) => ({
+//       ...params,
+//       [key]: value,
+//       page: 0,
+//     }));
+//   };
+//   const resetHandler = () => setQueryParams(null);
+//
+//   return (
+//     <FilterToolbar<AlertFilter>
+//       filters={[
+//         { key: "search", type: "SearchInput", label: "" },
+//         {
+//           key: "repositories",
+//           type: "MultiSelect",
+//           label: "Repositories",
+//           props: { options: repositories },
+//         },
+//       ]}
+//       values={{
+//         tab: queryParams.tab,
+//         search: queryParams.search,
+//         repositories: queryParams.repositories,
+//         pageIndex: queryParams.page,
+//         pageSize: queryParams.pageSize,
+//         property: queryParams.sortProperty,
+//         isDescending: queryParams.isDescending,
+//       }}
+//       defaultValues={{
+//         tab: "all",
+//         search: "",
+//         repositories: [],
+//         pageIndex: 0,
+//         pageSize: 10,
+//         property: "name",
+//         isDescending: false,
+//       }}
+//       onChange={changeHandler}
+//       onReset={resetHandler}
+//     />
+//   );
+// }

--- a/server/XUnitTest/Utilities/BlocksContextTestHelper.cs
+++ b/server/XUnitTest/Utilities/BlocksContextTestHelper.cs
@@ -1,58 +1,59 @@
-using System;
-using System.Linq;
-using Blocks.Genesis;
-
-namespace XUnitTest.Utilities
-{
-    public static class BlocksContextTestHelper
-    {
-        public static BlocksContext Create(
-            string tenantId,
-            string[] roles,
-            string userId,
-            bool isAuthenticated,
-            string requestUri,
-            string organizationId,
-            DateTime expireOn,
-            string? email,
-            string[]? permissions,
-            string userName,
-            string phoneNumber,
-            string displayName,
-            string oauthToken,
-            string refreshToken,
-            string? actualTenantId = null)
-        {
-            // var tId = actualTenantId ?? tenantId;
-            var safePermissions = permissions ?? Array.Empty<string>();
-
-            var createMethods = typeof(BlocksContext).GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
-                .Where(m => m.Name == "Create" && m.ReturnType == typeof(BlocksContext))
-                .ToList();
-
-            var create15Method = createMethods.FirstOrDefault(m => m.GetParameters().Length == 15);
-            if (create15Method != null)
-            {
-                return (BlocksContext)create15Method.Invoke(null, new object?[]
-                {
-                    tenantId, roles, userId, isAuthenticated, requestUri, organizationId,
-                    expireOn, email ?? string.Empty, safePermissions, userName, phoneNumber,
-                    displayName, oauthToken, actualTenantId, refreshToken
-                })!;
-            }
-
-            var create14Method = createMethods.FirstOrDefault(m => m.GetParameters().Length == 14);
-            if (create14Method != null)
-            {
-                return (BlocksContext)create14Method.Invoke(null, new object?[]
-                {
-                    tenantId, roles, userId, isAuthenticated, requestUri, organizationId,
-                    expireOn, email ?? string.Empty, safePermissions, userName, phoneNumber,
-                    displayName, oauthToken, actualTenantId
-                })!;
-            }
-
-            throw new InvalidOperationException("Could not find a compatible BlocksContext.Create method.");
-        }
-    }
-}
+// DEADCODE 2026-07-29: type(s) unreferenced anywhere in server or XUnitTest; whole file commented pending review
+// using System;
+// using System.Linq;
+// using Blocks.Genesis;
+//
+// namespace XUnitTest.Utilities
+// {
+//     public static class BlocksContextTestHelper
+//     {
+//         public static BlocksContext Create(
+//             string tenantId,
+//             string[] roles,
+//             string userId,
+//             bool isAuthenticated,
+//             string requestUri,
+//             string organizationId,
+//             DateTime expireOn,
+//             string? email,
+//             string[]? permissions,
+//             string userName,
+//             string phoneNumber,
+//             string displayName,
+//             string oauthToken,
+//             string refreshToken,
+//             string? actualTenantId = null)
+//         {
+//             // var tId = actualTenantId ?? tenantId;
+//             var safePermissions = permissions ?? Array.Empty<string>();
+//
+//             var createMethods = typeof(BlocksContext).GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+//                 .Where(m => m.Name == "Create" && m.ReturnType == typeof(BlocksContext))
+//                 .ToList();
+//
+//             var create15Method = createMethods.FirstOrDefault(m => m.GetParameters().Length == 15);
+//             if (create15Method != null)
+//             {
+//                 return (BlocksContext)create15Method.Invoke(null, new object?[]
+//                 {
+//                     tenantId, roles, userId, isAuthenticated, requestUri, organizationId,
+//                     expireOn, email ?? string.Empty, safePermissions, userName, phoneNumber,
+//                     displayName, oauthToken, actualTenantId, refreshToken
+//                 })!;
+//             }
+//
+//             var create14Method = createMethods.FirstOrDefault(m => m.GetParameters().Length == 14);
+//             if (create14Method != null)
+//             {
+//                 return (BlocksContext)create14Method.Invoke(null, new object?[]
+//                 {
+//                     tenantId, roles, userId, isAuthenticated, requestUri, organizationId,
+//                     expireOn, email ?? string.Empty, safePermissions, userName, phoneNumber,
+//                     displayName, oauthToken, actualTenantId
+//                 })!;
+//             }
+//
+//             throw new InvalidOperationException("Could not find a compatible BlocksContext.Create method.");
+//         }
+//     }
+// }


### PR DESCRIPTION
## Dead code pass (comment-only, fully reversible)

Every change is a comment-out with a `// DEADCODE 2026-07-29` marker on the first line. No file deleted, no live code modified. Restoring a file means deleting the marker line and stripping the leading `// ` from each line; byte-level reversibility was verified for every file against its previous git blob.

Verification on this exact tree:
- Client: `npm run build` succeeded; Vitest 26 files / 271 tests, all passed.
- Server: `dotnet build` of Api succeeded with 0 errors; XUnitTest 327 of 327 passed.
- E2E: result stated in the section below.

Method: knip over the client (router is a single static `routes` array, no `React.lazy`, no dynamic `import()`, no `import.meta.glob`; no test mass-imports route files), then independent grep re-verification of every candidate including all `@/*` aliases, then reduction to an import-closed set. Backend: both controllers (15 actions) were enumerated and grepped against this repo's client and e2e, then against every sibling repo under the org.

### A. Commented out (18 files)

Client, unreachable from `main.tsx` / the router tree (17 files):
- `client/app/components/common/loader-spinner/loader-spinner.tsx`
- `client/app/components/core/calendar/calendar/calendar.tsx` (duplicate nested copy; `calendar/calendar.tsx` is the live one)
- `client/app/components/core/collapsible/collapsible/collapsible.tsx` (duplicate nested copy)
- `client/app/components/core/drawer/drawer/drawer.tsx` (duplicate nested copy)
- `client/app/components/core/spinner-loader/spinner-loader.tsx`
- `client/app/components/core/stepper/` (all 11 files: `index.tsx`, `context.tsx`, `step.tsx`, `step-button-container.tsx`, `step-icon.tsx`, `step-label.tsx`, `horizontal-step.tsx`, `vertical-step.tsx`, `types.ts`, `use-media-query.tsx`, `use-stepper.ts`; the whole widget is unreferenced, same finding as blocks-iam and blocks-localization)
- `client/app/components/module/alert/alerts-filter-toolbar.tsx`

Server (1 file):
- `server/XUnitTest/Utilities/BlocksContextTestHelper.cs` (static test helper, zero references in the entire server tree; its namespace `XUnitTest.Utilities` is also declared by the live `MongoMocks.cs`, so the 12 `using XUnitTest.Utilities;` directives keep compiling)

### B. Candidates left for review (NOT commented)

Endpoints: none are dead. All 15 controller actions are consumed by this repo's client via `endpoint.constant.ts`, except `GET /Health/Ping/{itemId}`, which is kept because it is the deliberately anonymous external heartbeat receiver, documented public SDK surface of the shipped NuGet package `SeliseBlocks.MonitorDriver.OS` (`Observability.Driver/README.md`), and referenced by `HealthControllerTests`.

Server:
- `server/Alert.DomainService/Monitor/Entity/MonitorIncidentLog.cs`: empty `[BsonIgnoreExtraElements]` entity class with zero references anywhere including tests. Left because it is a DB entity type; a human should confirm no Mongo collection or serialization path depends on it, after which it is a trivial removal.
- `server/Observability.Driver/ObservabilityDriverServiceExtension.cs`: unreferenced in this solution but it is the DI entrypoint of the shipped NuGet package (blocks-logic consumes the package); public API constraint, untouchable.

Client:
- `client/app/__tests__/stubs/blocks-kit-components.tsx`: flagged by knip but it is the vitest alias stub for `@seliseblocks/genesis-os/components` (`vitest.config.ts:26`); live test infrastructure.
- Unused dependencies per knip (dependency changes out of scope for this pass): `@beefree.io/sdk`, `@hcaptcha/react-hcaptcha`, `@mailupinc/bee-plugin`, `@microsoft/signalr`, `@radix-ui/react-alert-dialog`, `@radix-ui/react-icons`, `@types/react-syntax-highlighter`, `framer-motion`, `jwt-decode`, `react-dropzone`, `react-qr-code`, `react-syntax-highlighter`, `sonner`, `uuid`; dev: `@types/uuid`, `husky`, `lint-staged`. Several look like copy-paste from a sibling repo's package.json and deserve a dedicated dependency-pruning pass (`@microsoft/signalr` in particular should be double-checked for runtime use before removal).
- 97 unused named exports inside live files (ui-kit re-exports and type exports); left as no-touch.
