### PR TITLE
emit lcov so sonar sees coverage

### DIFF
--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -45,10 +45,12 @@ export default defineConfig({
     setupFiles: ["./vitest.setup.ts"],
     css: false,
     coverage: {
-      reporter: ["text", "lcov"],
       all: true,
       provider: "v8",
-      reporter: ["text", "text-summary"],
+      // lcov must stay in this list - it is the only format SonarQube reads.
+      // A duplicate `reporter` key previously overrode it, so coverage was
+      // computed but never written and Sonar reported 0%.
+      reporter: ["text", "text-summary", "lcov"],
       include: ["app/**/*.{ts,tsx}"],
       exclude: [
         "app/**/*.test.*",


### PR DESCRIPTION
`client/vitest.config.ts` had a duplicate `reporter` key in `test.coverage`:

```
line 48:  reporter: ["text", "lcov"]          <- overridden
line 51:  reporter: ["text", "text-summary"]  <- wins, no lcov emitted
```

The later key wins in JS, so the lcov reporter never ran. Coverage was computed (93.39% lines) but never written, so the scanner logged:

```
No LCOV files were found using coverage/lcov.info
WARN No coverage information will be saved because all LCOV files cannot be found.
```

Sonar therefore recorded 0% coverage and the Quality Gate failed.

Merged into one reporter list including `lcov`. Verified in node:22 — `coverage/lcov.info` is now produced (41 KB), coverage unchanged.