### PR TITLE
[#194] SPEC - Fix Uptime column on Monitor table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,11 @@ results/
 QWEN.md
 .clinerules
 .windsurfrules
+
+# --- local tooling scripts (Windows + bash) - do not commit ---
+scripts/scan.ps1
+scripts/deploy.sh
+scripts/deploy.ps1
+scripts/th_transform.py
+scripts/secrets.local.ps1
+deploy.log

--- a/client/app/__tests__/module/alert/alerts-list.test.tsx
+++ b/client/app/__tests__/module/alert/alerts-list.test.tsx
@@ -178,4 +178,180 @@ describe("AlertsList", () => {
     );
     expect(container.querySelector("svg.lucide-arrow-down")).toBeTruthy();
   });
+
+  // -------------------------------------------------------------------------
+  // Uptime column (issue #194)
+  //
+  // The cell used to render `Date.now() - incidentTime` -- an elapsed duration
+  // that Intl read as a millisecond epoch, so every row showed a 1970 date.
+  //
+  // `formatDate` renders in local time, so no fixed instant formats the same in
+  // every zone. Expected strings are derived from the expected Date with the
+  // same formatter, which keeps each assertion about *which* date the cell
+  // picks rather than about the runner's timezone.
+  // -------------------------------------------------------------------------
+
+  const expectedUptime = (date: Date) =>
+    new Intl.DateTimeFormat("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    }).format(date);
+
+  const renderRows = (rows: AlertTree[]) =>
+    render(
+      <AlertsList data={rows} isLoading={false} sortQueryParams={sort} onSortChange={vi.fn()} />,
+      { wrapper: wrapper() },
+    );
+
+  // The model declares lastIncidentAt as a required Date, but the API also sends
+  // ISO strings, null, and the DateTime.MinValue sentinel -- which is exactly why
+  // the cell normalises them. Cast so the fixtures can express the real shapes.
+  const uptimeRow = (over: Record<string, unknown>): AlertTree => alert(over as Partial<AlertTree>);
+
+  it("shows the created date when a monitor has never had an incident", () => {
+    // H1
+    const created = new Date("2026-01-05T09:00:00Z");
+    renderRows([uptimeRow({ lastIncidentAt: null, createdDate: created.toISOString() })]);
+    expect(screen.getByText(expectedUptime(created))).toBeInTheDocument();
+  });
+
+  it("shows the incident date when a monitor has had one", () => {
+    // H2
+    const incident = new Date("2026-08-10T09:00:00Z");
+    renderRows([uptimeRow({ lastIncidentAt: incident, createdDate: "2025-06-01T09:00:00Z" })]);
+    expect(screen.getByText(expectedUptime(incident))).toBeInTheDocument();
+  });
+
+  it("shows the incident date when it arrives as an ISO string", () => {
+    // H2 -- the API sends a string even though the model declares Date
+    const incident = new Date("2026-08-10T09:00:00Z");
+    renderRows([
+      uptimeRow({
+        lastIncidentAt: incident.toISOString(),
+        createdDate: "2025-06-01T09:00:00Z",
+      }),
+    ]);
+    expect(screen.getByText(expectedUptime(incident))).toBeInTheDocument();
+  });
+
+  it("treats a blank incident string as no incident rather than 1970", () => {
+    // new Date("  ") is Invalid Date, so this must fall through to createdDate
+    const created = new Date("2026-04-02T09:00:00Z");
+    renderRows([uptimeRow({ lastIncidentAt: "  ", createdDate: created.toISOString() })]);
+    expect(screen.getByText(expectedUptime(created))).toBeInTheDocument();
+    expect(screen.queryByText(/19(69|70|71)/)).toBeNull();
+  });
+
+  it("treats the DateTime.MinValue sentinel as no incident", () => {
+    // C1 -- and never a year-1 or 1970 date
+    const created = new Date("2026-02-01T09:00:00Z");
+    renderRows([
+      uptimeRow({
+        lastIncidentAt: "0001-01-01T00:00:00Z",
+        createdDate: created.toISOString(),
+      }),
+    ]);
+    expect(screen.getByText(expectedUptime(created))).toBeInTheDocument();
+    expect(screen.queryByText(/19(69|70|71)/)).toBeNull();
+    expect(screen.queryByText(/, 0{0,3}1$/)).toBeNull();
+  });
+
+  it("treats a MinValue sentinel with a positive UTC offset as no incident", () => {
+    // C1 -- 0001-01-01T00:00:00+14:00 lands in UTC year 0, not year 1
+    const created = new Date("2026-03-09T09:00:00Z");
+    renderRows([
+      uptimeRow({
+        lastIncidentAt: "0001-01-01T00:00:00+14:00",
+        createdDate: created.toISOString(),
+      }),
+    ]);
+    expect(screen.getByText(expectedUptime(created))).toBeInTheDocument();
+  });
+
+  it("keeps the incident date even when the monitor was created more recently", () => {
+    // C4
+    const incident = new Date("2024-04-04T09:00:00Z");
+    renderRows([uptimeRow({ lastIncidentAt: incident, createdDate: "2026-05-05T09:00:00Z" })]);
+    expect(screen.getByText(expectedUptime(incident))).toBeInTheDocument();
+    expect(screen.queryByText(expectedUptime(new Date("2026-05-05T09:00:00Z")))).toBeNull();
+  });
+
+  it("computes the uptime date independently for each row", () => {
+    // H4
+    const a = new Date("2026-01-05T09:00:00Z");
+    const b = new Date("2026-08-10T09:00:00Z");
+    const c = new Date("2026-02-01T09:00:00Z");
+    renderRows([
+      uptimeRow({ itemId: "r1", name: "A", lastIncidentAt: null, createdDate: a.toISOString() }),
+      uptimeRow({
+        itemId: "r2",
+        name: "B",
+        lastIncidentAt: b,
+        createdDate: "2020-01-01T09:00:00Z",
+      }),
+      uptimeRow({
+        itemId: "r3",
+        name: "C",
+        lastIncidentAt: "0001-01-01T00:00:00Z",
+        createdDate: c.toISOString(),
+      }),
+    ]);
+    expect(screen.getByText(expectedUptime(a))).toBeInTheDocument();
+    expect(screen.getByText(expectedUptime(b))).toBeInTheDocument();
+    expect(screen.getByText(expectedUptime(c))).toBeInTheDocument();
+  });
+
+  it("renders a placeholder instead of throwing when no usable date exists", () => {
+    // C2 -- lastIncidentAt must also be unusable, or the guard is never reached
+    expect(() =>
+      renderRows([uptimeRow({ lastIncidentAt: null, createdDate: "not-a-date" })]),
+    ).not.toThrow();
+    expect(screen.getByText("-")).toBeInTheDocument();
+    expect(screen.queryByText(/19(69|70|71)/)).toBeNull();
+  });
+
+  it("renders a placeholder when createdDate is null rather than falling back to 1970", () => {
+    // C2 -- new Date(null) is a valid epoch date, which is exactly the 1970 leak
+    renderRows([uptimeRow({ lastIncidentAt: null, createdDate: null })]);
+    expect(screen.getByText("-")).toBeInTheDocument();
+    expect(screen.queryByText(/19(69|70|71)/)).toBeNull();
+  });
+
+  it("renders the same date regardless of the current time", () => {
+    // C3, C5 -- the cell must not derive anything from Date.now()
+    const incident = new Date("2026-08-10T09:00:00Z");
+    const row = uptimeRow({ lastIncidentAt: incident, createdDate: "2025-06-01T09:00:00Z" });
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-11T00:00:00Z"));
+      const first = renderRows([row]);
+      const early = first.container.textContent;
+      first.unmount();
+
+      vi.setSystemTime(new Date("2031-12-31T00:00:00Z"));
+      const second = renderRows([row]);
+      expect(second.container.textContent).toBe(early);
+      expect(screen.getByText(expectedUptime(incident))).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("leaves the status arrow untouched by the uptime fix", () => {
+    // H5
+    const created = new Date("2026-01-05T09:00:00Z");
+    const { container, unmount } = renderRows([
+      uptimeRow({ lastIncidentAt: null, createdDate: created.toISOString(), currentStatus: true }),
+    ]);
+    expect(container.querySelector("svg.lucide-arrow-up")).toBeTruthy();
+    expect(screen.getByText(expectedUptime(created))).toBeInTheDocument();
+    unmount();
+
+    const down = renderRows([
+      uptimeRow({ lastIncidentAt: null, createdDate: created.toISOString(), currentStatus: false }),
+    ]);
+    expect(down.container.querySelector("svg.lucide-arrow-down")).toBeTruthy();
+  });
 });

--- a/client/app/components/module/alert/alerts-list.tsx
+++ b/client/app/components/module/alert/alerts-list.tsx
@@ -30,6 +30,37 @@ type AlertsListProps = {
   onSortChange: (params: SortValue) => void;
 };
 
+const UPTIME_DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+};
+
+const EMPTY_VALUE = "-";
+
+/**
+ * The model types the incident date as `Date`, but the API also sends an ISO
+ * string, null, and the C# `DateTime.MinValue` sentinel. Normalise all of them
+ * here and return null for anything unusable, so no caller can hand an invalid
+ * Date to `Intl.DateTimeFormat` (which throws rather than degrading).
+ */
+const toValidDate = (value: Date | string | null | undefined): Date | null => {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+/**
+ * `DateTime.MinValue` is year 0001 UTC, but a positive UTC offset pushes it back
+ * into year 0, so treat anything at or below year 1 as "no incident recorded".
+ *
+ * This is deliberately a year check rather than an exact match on the minimum
+ * date: the ticket specifies one (C1), and it stays correct however the backend
+ * serialises the sentinel. The tradeoff is that a genuine year-1 timestamp would
+ * also be read as "never" -- not a real case for uptime monitoring.
+ */
+const isNeverSentinel = (date: Date) => date.getUTCFullYear() <= 1;
+
 export function AlertsList({ data, isLoading, sortQueryParams, onSortChange }: AlertsListProps) {
   const navigate = useNavigate();
   const scoped = useScopedPath();
@@ -141,13 +172,19 @@ export function AlertsList({ data, isLoading, sortQueryParams, onSortChange }: A
         ),
         cell: ({ row }) => {
           const { lastIncidentAt, currentStatus, createdDate } = row.original;
-          const lastIncidentDateStr = lastIncidentAt ?? createdDate;
-          const zeroDate = new Date("0001-01-01T00:00:00Z").getTime();
-          const lastIncidentTime = new Date(lastIncidentDateStr).getTime();
-          const createdTime = new Date(createdDate).getTime();
-          const incidentTime = lastIncidentTime === zeroDate ? createdTime : lastIncidentTime;
-          const uptime = Date.now() - incidentTime;
-          const formattedDate = formatDate(uptime);
+
+          // Show the date of the last incident, or when the service was created
+          // if nothing has happened yet. This used to format `Date.now() - time`,
+          // an elapsed duration, which Intl read as a millisecond epoch and
+          // rendered as a date in 1970.
+          const incidentDate = toValidDate(lastIncidentAt as Date | string | null);
+          const uptimeDate =
+            incidentDate && !isNeverSentinel(incidentDate)
+              ? incidentDate
+              : toValidDate(createdDate);
+          const formattedDate = uptimeDate
+            ? formatDate(uptimeDate, UPTIME_DATE_FORMAT)
+            : EMPTY_VALUE;
 
           return (
             <div className="ml-2 flex w-[180px] items-center sm:ml-0 sm:w-[150px]">


### PR DESCRIPTION
## Ticket

#194 — https://github.com/SELISEdigitalplatforms/blocks-monitor/issues/194

## What changed

The Uptime column on the Monitor table showed a date in 1970 for every row. It now shows the date of the service's last incident, or the date the service was created if it has never had one.

The cause: the cell computed `Date.now() - incidentTime` — an elapsed duration in milliseconds — and passed that number to `formatDate`, which reads a number as milliseconds since the epoch. A duration of a few hundred million ms is a few days after 1 January 1970, so that is what every row displayed. The fix stops subtracting and formats the chosen date itself.

### Notes for the reviewer

- **Sentinel detection is by year, as the ticket specifies.** The backend sends `DateTime.MinValue` to mean "no incident yet". C1 calls for a year-based check rather than an epoch comparison, so that is what this does — with one extension: `0001-01-01T00:00:00+14:00` lands in UTC year **0**, not year 1, so the check is `getUTCFullYear() <= 1`. The tradeoff is that a genuine year-1 timestamp would also read as "never", which is not a real case for uptime monitoring. Flagged rather than buried.
- **One deliberate departure from the spec's premise.** §3 of the ticket states that malformed dates "already produce `Invalid Date` via existing formatDate, unchanged". That is not true on this path: with `Intl` options, `formatDate` calls `Intl.DateTimeFormat.format`, which throws `RangeError: Invalid time value`. C2 requires "no new crash", so the cell checks the date before formatting and renders `-` when there is nothing usable — matching how the neighbouring columns in this same table show a missing value. Without this, a null `createdDate` would also have re-created the exact 1970 symptom, since `new Date(null)` is a valid epoch date.
- **Short month format.** The ticket's examples show `"Jan 5, 2026"`, but `formatDate`'s default options produce `"January 5, 2026"`. H3 says to match the style used elsewhere in the app, and `progress-bar.tsx:94-99` — the only other date rendering in this module — uses the short form, which agrees with the examples. The cell passes those options explicitly. One constant to change if the team wants otherwise.
- **The model's typing is left alone.** `AlertTree.lastIncidentAt` is declared as a required `Date`, while the API also sends ISO strings, `null`, and the sentinel. Retyping the model is out of scope for this fix, so the cell normalises all of those shapes instead and the tests cast fixtures to express them.
- **One commit in this PR is not mine.** `12d7a21 chore: ignore local scan/deploy tooling` was already on `inception` and not yet in `dev` when this work started. It is left as it is. This ticket's change is the single commit `44497c6`, touching 2 files.

## Testing

- **Unit:** 12 new tests in `client/app/__tests__/module/alert/alerts-list.test.tsx` — the file the ticket's §9 names. That suite now runs 21 tests; the full client suite is **294 tests across 28 files, all passing**.
- **Coverage:** `alerts-list.tsx` at **96.15% lines / 83.72% branches** (`npm run test:coverage` — note that plain `npm test` collects none).
- **Gates:** `npm run lint` clean on both changed files (the one warning is a pre-existing TanStack Table notice unrelated to this diff), `tsc --noEmit` passes.
- **Timezone.** `formatDate` renders in local time, so no fixed instant formats identically in every zone. Each expected string is computed in the test from the expected `Date` with the same `Intl.DateTimeFormat`, keeping every assertion about *which* date the cell picks rather than about the runner's timezone.
- **On C5 specifically.** The cell is tested by rendering the same row under two fake clocks five years apart and requiring byte-identical output — that fails the moment anything time-dependent re-enters the cell. To be precise about what that proves: it guarantees the rendered date cannot vary with the current time, not the literal absence of a `Date.now()` call from the source. The latter is visible in the diff.
- **e2e:** not executed. §7 needs a tenant seeded with at least two monitors, one with a recorded incident and one without; this change did not provision or mutate any environment. Every §7 step has an equivalent component test, but **the browser walkthrough still needs a human pass before merge**.

## Review

codex (gpt-5.6-sol, high effort): 2 cycles on the plan, 2 cycles on the final diff.
Self-review: 2 cycles.

Plan review was unusually productive here: cycle 1 raised 3 critical and 3 major, including that `formatDate` throws rather than degrading on a bad date, and that my coverage gate could not have measured anything. Cycle 2 raised a further critical — `new Date(lastIncidentAt)` would not have compiled against the model's `Date` type — plus the UTC year-0 offset gap and the `new Date(null)` 1970 leak, all of which were fixed in the plan before any code was written.

Code review cycle 1 returned 0 critical / 0 major / 3 minor. One was a real coverage gap (no test for a non-sentinel incident arriving as an ISO string, the production shape) and is fixed. One suggested narrowing the sentinel check away from a year comparison, which the ticket explicitly mandates — kept, with the tradeoff documented in a comment. One claimed a whitespace-only date string would render as 1970; I verified with node that `new Date("  ")` is `Invalid Date`, so it falls through correctly, and added a test pinning it. Cycle 2 confirmed the rejection and came back clean.

No unresolved critical findings.
