### PR TITLE
feat: open monitor settings and default timeouts to 30s when adding a monitor

### DIFF
--- a/client/app/__tests__/module/monitor/form/controller.test.tsx
+++ b/client/app/__tests__/module/monitor/form/controller.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { renderHook, act, waitFor } from "@testing-library/react";
+import { renderHook, render as renderComponent, act, waitFor } from "@testing-library/react";
 
 const h = vi.hoisted(() => ({
   addAsync: vi.fn(),
@@ -88,6 +88,94 @@ describe("useMonitorFormController", () => {
     const { result } = render({ mode: "edit", itemId: "m1", projectKey: "p1" });
     expect(result.current.isEditMode).toBe(true);
     expect(result.current.form.getValues("name")).toBe("existing");
+  });
+
+  /**
+   * react-hook-form seeds its state from `defaultValues` and only reconciles the
+   * `values` prop in an effect, so seeding with the add defaults makes edit mode's
+   * FIRST render show 30s before settling on the real value. Neither getValues() after
+   * renderHook nor formState.defaultValues can see that — both are post-reconciliation.
+   * Recording the value on every render is what actually catches it: with the bug the
+   * sequence is [1, 3], without it [3, 3].
+   */
+  const valuesPerRender = (params: Parameters<typeof useMonitorFormController>[0]) => {
+    const seen: unknown[] = [];
+    function Probe() {
+      const controller = useMonitorFormController(params);
+      seen.push(controller.form.getValues("monitorSettings.request_timeout"));
+      return null;
+    }
+    renderComponent(<Probe />);
+    return seen;
+  };
+
+  it("never shows the add default on the edit form's first render", () => {
+    const seen = valuesPerRender({ mode: "edit", itemId: "m1", projectKey: "p1" });
+    expect(seen[0]).toBe(3);
+    expect(seen).not.toContain(getMonitorFormDefaultValues().monitorSettings.request_timeout);
+  });
+
+  // Edit's placeholder-then-saved-value sequence is unchanged from before this ticket:
+  // the 5min fallback first, then the monitor's real 60s value. Asserted as first/last
+  // rather than an exact array, so an extra render does not fail a correct sequence.
+  it("keeps the edit form's placeholder-then-saved-value sequence", () => {
+    h.monitorById.data = {
+      data: { name: "existing", monitorConfigurationType: 0, timeoutInSeconds: 60 },
+    };
+    const seen = valuesPerRender({ mode: "edit", itemId: "m1", projectKey: "p1" });
+    expect(seen[0]).toBe(3);
+    // step 2 = 60s: neither the add default (1) nor the edit fallback (3)
+    expect(seen.at(-1)).toBe(2);
+    expect(seen).not.toContain(1);
+  });
+
+  it("never shows the edit fallback on the add form, first render or settled", () => {
+    const seen = valuesPerRender({ mode: "add", projectKey: "p1" });
+    expect(seen[0]).toBe(1);
+    expect(new Set(seen)).toEqual(new Set([1]));
+  });
+
+  /**
+   * H2/H3/H5 at the controller level. The field tests build their own form and the payload
+   * tests call getMonitorFormDefaultValues directly, so without this nothing connects the
+   * real controller's settled state to what a user submits: a controller that reconciled
+   * add mode onto the 5min fallback would pass every other test in this change.
+   */
+  it("settles the add form on 30s and submits it (H2, H3, H5)", async () => {
+    h.addAsync.mockResolvedValue({ isSuccess: true, data: { itemId: "new-1" } });
+    const { result } = render({ mode: "add", projectKey: "p1" });
+
+    expect(result.current.form.getValues("monitorSettings.request_timeout")).toBe(1);
+    expect(result.current.form.getValues("monitorSettings.grace_time")).toBe(1);
+
+    act(() => {
+      result.current.form.setValue("name", "svc");
+      result.current.form.setValue("urlMonitor", "https://svc.example.com");
+    });
+    await act(async () => {
+      await result.current.submit(result.current.form.getValues());
+    });
+
+    expect(h.addAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutInSeconds: 30, intervalInSeconds: 60 }),
+    );
+  });
+
+  it("submits a 30s grace period for a callback monitor (H3, H5)", async () => {
+    h.saveHealthAsync.mockResolvedValue({ isSuccess: true, data: { itemId: "new-2" } });
+    const { result } = render({ mode: "add", projectKey: "p1" });
+
+    act(() => {
+      result.current.form.setValue("name", "svc");
+      result.current.setMonitorType("callback");
+    });
+    await act(async () => {
+      await result.current.submit(result.current.form.getValues());
+    });
+
+    expect(h.saveHealthAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ gracePeriodInSeconds: 30 }),
+    );
   });
 
   it("setSourceType clears the opposing selection", () => {

--- a/client/app/__tests__/module/monitor/form/form-fields.test.tsx
+++ b/client/app/__tests__/module/monitor/form/form-fields.test.tsx
@@ -5,6 +5,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Dialog } from "@/components/core";
 import { MonitorFormFields } from "@/components/module/monitor/form/monitor-form-fields";
+import { MonitorModal } from "@/components/module/monitor/modal/monitor-modal";
 import {
   getMonitorFormDefaultValues,
   monitorFormSchema,
@@ -65,7 +66,7 @@ describe("MonitorFormFields", () => {
   });
 
   it("hides monitor type and shows the locked note in edit mode", () => {
-    render(<Harness overrides={{ isEditMode: true }} />);
+    render(<Harness overrides={{ mode: "edit", isEditMode: true }} />);
     expect(screen.queryByText("Monitor type")).toBeNull();
     expect(
       screen.getByText("Monitor source cannot be changed for existing monitors."),
@@ -106,10 +107,11 @@ describe("MonitorFormFields", () => {
     expect(onSourceTypeChange).toHaveBeenCalledWith("deployed");
   });
 
-  it("expands the monitor settings accordion to reveal the interval slider", async () => {
+  // Was: clicked "Monitor settings" first. In add mode the accordion now starts open,
+  // so that click would collapse it and Radix would unmount the content.
+  it("shows the interval and timeout sliders in the monitor settings accordion", () => {
     render(<Harness />);
-    await userEvent.click(screen.getByRole("button", { name: /Monitor settings/ }));
-    expect(await screen.findByText("Monitor interval")).toBeInTheDocument();
+    expect(screen.getByText("Monitor interval")).toBeInTheDocument();
     expect(screen.getByText("Request timeout")).toBeInTheDocument();
   });
 
@@ -138,12 +140,132 @@ describe("MonitorFormFields", () => {
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
   });
 
-  it("shows the grace-time slider for callback monitors", async () => {
+  // Was: clicked "Monitor settings" first — same inversion as above.
+  it("shows the grace-time slider for callback monitors", () => {
     render(<Harness overrides={{ monitorType: "callback" }} />);
-    await userEvent.click(screen.getByRole("button", { name: /Monitor settings/ }));
-    expect(await screen.findByText("Grace Time")).toBeInTheDocument();
+    expect(screen.getByText("Grace Time")).toBeInTheDocument();
     // request-only config accordion is absent for callbacks
     expect(screen.queryByText("Request Configuration")).toBeNull();
+  });
+});
+
+describe("MonitorFormFields monitor settings defaults", () => {
+  const settingsTrigger = () => screen.getByRole("button", { name: /Monitor settings/ });
+
+  /**
+   * The slider renders every tick label ("30s", "1min", ...) unconditionally and shows
+   * no current-value text, so asserting on "30s" would pass whatever the default is.
+   * The value lives on the Radix thumb's aria-valuenow; scope by label because both
+   * sliders in the accordion expose role="slider".
+   */
+  const sliderFor = (label: string) =>
+    within(screen.getByText(label).closest("div")!).getByRole("slider");
+
+  it("opens the accordion in add mode without any interaction (H1)", () => {
+    render(<Harness />);
+    expect(settingsTrigger()).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Monitor interval")).toBeInTheDocument();
+  });
+
+  it("defaults the request timeout to 30s for request monitors (H2, C3)", () => {
+    render(<Harness />);
+    expect(sliderFor("Request timeout")).toHaveAttribute("aria-valuenow", "1");
+    expect(screen.queryByText("Grace Time")).toBeNull();
+  });
+
+  it("defaults the grace time to 30s for callback monitors (H3, C4)", () => {
+    render(<Harness overrides={{ monitorType: "callback" }} />);
+    expect(sliderFor("Grace Time")).toHaveAttribute("aria-valuenow", "1");
+    expect(screen.queryByText("Request timeout")).toBeNull();
+  });
+
+  it("leaves the monitor interval at 1min (H4)", () => {
+    render(<Harness />);
+    expect(sliderFor("Monitor interval")).toHaveAttribute("aria-valuenow", "2");
+  });
+
+  it("keeps the accordion collapsed in edit mode but still toggleable (C1)", async () => {
+    render(<Harness overrides={{ mode: "edit", isEditMode: true }} />);
+
+    expect(settingsTrigger()).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Monitor interval")).toBeNull();
+
+    // The second half of C1: collapsed by default, but the user can still open it.
+    // Without this, an edit trigger that ignored clicks would satisfy every other
+    // assertion here, since C5 only exercises add mode where it starts open.
+    await userEvent.click(settingsTrigger());
+    expect(await screen.findByText("Monitor interval")).toBeInTheDocument();
+  });
+
+  it("shows the monitor's saved timeout in edit mode, not the add default (C2)", async () => {
+    render(
+      <Harness
+        overrides={{ mode: "edit", isEditMode: true }}
+        initialValues={{
+          monitorSettings: {
+            ...getMonitorFormDefaultValues().monitorSettings,
+            // step 2 = 60s: neither the add default (1) nor the edit fallback (3)
+            request_timeout: 2,
+          },
+        }}
+      />,
+    );
+
+    await userEvent.click(settingsTrigger());
+    expect(await screen.findByText("Request timeout")).toBeInTheDocument();
+    expect(sliderFor("Request timeout")).toHaveAttribute("aria-valuenow", "2");
+  });
+
+  it("lets the user collapse the accordion again in add mode (C5)", async () => {
+    render(<Harness />);
+    expect(settingsTrigger()).toHaveAttribute("aria-expanded", "true");
+
+    await userEvent.click(settingsTrigger());
+
+    expect(settingsTrigger()).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Monitor interval")).toBeNull();
+  });
+});
+
+/**
+ * Section 4 example 5: reopening "Add monitor" after fiddling with the settings shows
+ * the defaults again. Driven through the real MonitorModal rather than a bare RTL
+ * unmount, because what makes this work is that DialogContent unmounts its children
+ * when closed — a forceMount or lifted-state change would break the behaviour while a
+ * hand-rolled unmount test carried on passing.
+ */
+describe("reopening the add-monitor modal", () => {
+  function ModalHarness({ open }: { open: boolean }) {
+    return (
+      <MonitorModal open={open} onOpenChange={() => {}} itemId={null}>
+        <Harness />
+      </MonitorModal>
+    );
+  }
+
+  it("restores the open accordion and the 30s default", async () => {
+    const trigger = () => screen.getByRole("button", { name: /Monitor settings/ });
+    const timeoutSlider = () =>
+      within(screen.getByText("Request timeout").closest("div")!).getByRole("slider");
+
+    const view = render(<ModalHarness open />);
+
+    // Dirty both pieces of state first. Asserting the default without moving it off
+    // the default would prove nothing at all.
+    await userEvent.click(timeoutSlider());
+    await userEvent.keyboard("{ArrowRight}");
+    expect(timeoutSlider()).toHaveAttribute("aria-valuenow", "2");
+
+    await userEvent.click(trigger());
+    expect(trigger()).toHaveAttribute("aria-expanded", "false");
+
+    view.rerender(<ModalHarness open={false} />);
+    expect(screen.queryByRole("button", { name: /Monitor settings/ })).toBeNull();
+
+    view.rerender(<ModalHarness open />);
+
+    expect(trigger()).toHaveAttribute("aria-expanded", "true");
+    expect(timeoutSlider()).toHaveAttribute("aria-valuenow", "1");
   });
 });
 

--- a/client/app/__tests__/module/monitor/form/schema.test.ts
+++ b/client/app/__tests__/module/monitor/form/schema.test.ts
@@ -18,6 +18,23 @@ describe("getMonitorFormDefaultValues", () => {
   it("respects an explicit configuration type", () => {
     expect(getMonitorFormDefaultValues("callback").monitorConfigurationType).toBe("callback");
   });
+
+  // Steps, not seconds: 1 = 30s, 2 = 1min, 3 = 5min.
+  it("defaults request timeout and grace time to 30s (step 1)", () => {
+    const v = getMonitorFormDefaultValues();
+    expect(v.monitorSettings.request_timeout).toBe(1);
+    expect(v.monitorSettings.grace_time).toBe(1);
+  });
+
+  it("leaves the monitor interval at 1min (step 2)", () => {
+    expect(getMonitorFormDefaultValues().monitorSettings.monitor_interval).toBe(2);
+  });
+
+  it("applies the 30s timeout defaults to callback monitors too", () => {
+    const v = getMonitorFormDefaultValues("callback");
+    expect(v.monitorSettings.grace_time).toBe(1);
+    expect(v.monitorSettings.request_timeout).toBe(1);
+  });
 });
 
 describe("monitorFormSchema", () => {

--- a/client/app/__tests__/module/monitor/form/util.test.ts
+++ b/client/app/__tests__/module/monitor/form/util.test.ts
@@ -72,8 +72,26 @@ describe("toSeconds", () => {
 });
 
 describe("toFormValuesFromMonitorDetails", () => {
-  it("returns defaults when no details are supplied", () => {
-    expect(toFormValuesFromMonitorDetails(undefined)).toEqual(getMonitorFormDefaultValues());
+  // Was `toEqual(getMonitorFormDefaultValues())`. The edit form deliberately no longer
+  // inherits the add defaults for the two timeout fields, so equality with a moving
+  // target is both wrong and weaker than naming the expected shape.
+  it("returns the add defaults except for the pinned edit timeout fallbacks", () => {
+    const defaults = getMonitorFormDefaultValues();
+    expect(toFormValuesFromMonitorDetails(undefined)).toEqual({
+      ...defaults,
+      monitorSettings: {
+        ...defaults.monitorSettings,
+        request_timeout: 3,
+        grace_time: 3,
+      },
+    });
+  });
+
+  it("keeps the edit fallback at 5min even though add now defaults to 30s", () => {
+    const values = toFormValuesFromMonitorDetails(undefined);
+    expect(values.monitorSettings.request_timeout).toBe(3);
+    expect(values.monitorSettings.grace_time).toBe(3);
+    expect(getMonitorFormDefaultValues().monitorSettings.request_timeout).toBe(1);
   });
 
   it("maps monitor details into form values", () => {
@@ -103,6 +121,10 @@ describe("toFormValuesFromMonitorDetails", () => {
     expect(values.urlMonitor).toBe("https://svc.example.com");
     expect(values.monitorSettings.monitor_interval).toBe(2);
     expect(values.monitorSettings.grace_time).toBe(3);
+    // The fixture saves a 30s timeout, so this must be step 1 — asserted because the
+    // grace assertion above uses step 3, which is also the fallback and so cannot
+    // distinguish reading the saved value from ignoring it.
+    expect(values.monitorSettings.request_timeout).toBe(1);
     expect(values.monitorSettings.check_ssl_errors).toBe(true);
     expect(values.requestConfiguration.http_methods).toBe("2");
     expect(values.requestConfiguration.request_body).toBe('{"a":1}');
@@ -131,6 +153,24 @@ describe("toFormValuesFromMonitorDetails", () => {
     } as unknown as IMonitorDetails);
     expect(values.requestConfiguration.x_header_name).toBe("");
     expect(values.requestConfiguration.json_switcher).toBe(false);
+  });
+
+  // C2. 60s is step 2 — neither the add default (1) nor the edit fallback (3) — so an
+  // implementation that ignored the saved value and returned either constant fails.
+  it("hydrates a saved request timeout that is neither the add default nor the fallback", () => {
+    const values = toFormValuesFromMonitorDetails({
+      monitorConfigurationType: 0,
+      timeoutInSeconds: 60,
+    } as unknown as IMonitorDetails);
+    expect(values.monitorSettings.request_timeout).toBe(2);
+  });
+
+  it("hydrates a saved grace period that is neither the add default nor the fallback", () => {
+    const values = toFormValuesFromMonitorDetails({
+      monitorConfigurationType: 1,
+      gracePeriodInSeconds: 60,
+    } as unknown as IMonitorDetails);
+    expect(values.monitorSettings.grace_time).toBe(2);
   });
 });
 
@@ -206,5 +246,32 @@ describe("payload builders", () => {
     const payload = toUpdateCallbackPayload(values, context);
     expect(payload.itemId).toBe("item-1");
     expect(payload.monitorConfigurationType).toBe(1);
+  });
+});
+
+// H5: what a user actually saves when they add a monitor and never touch the sliders.
+// This goes through the real payload builders rather than asserting toSeconds(1) in
+// isolation, so a default that never reached the wire would still fail.
+describe("submitting untouched add-mode defaults", () => {
+  it("sends a 30 second timeout for a request monitor", () => {
+    const payload = toCreateRequestPayload(
+      {
+        ...getMonitorFormDefaultValues("request"),
+        name: "svc",
+        urlMonitor: "https://svc.example.com",
+      },
+      context,
+    );
+    expect(payload.timeoutInSeconds).toBe(30);
+    expect(payload.intervalInSeconds).toBe(60);
+  });
+
+  it("sends a 30 second grace period for a callback monitor", () => {
+    const payload = toCreateCallbackPayload(
+      { ...getMonitorFormDefaultValues("callback"), name: "svc" },
+      context,
+    );
+    expect(payload.gracePeriodInSeconds).toBe(30);
+    expect(payload.intervalInSeconds).toBe(60);
   });
 });

--- a/client/app/components/module/monitor/form/monitor-form-fields.tsx
+++ b/client/app/components/module/monitor/form/monitor-form-fields.tsx
@@ -250,7 +250,17 @@ export const MonitorFormFields = ({
             </RenderConditionally>
           </div>
 
-          <Accordion type="single" collapsible className="w-full">
+          {/*
+            Add opens "Monitor settings" for you, since a new monitor almost always
+            needs these set. defaultValue rather than value keeps it uncontrolled, so
+            it is an initial state the user can still collapse. Edit is left alone.
+          */}
+          <Accordion
+            type="single"
+            collapsible
+            defaultValue={isEditMode ? undefined : "monitorSettings"}
+            className="w-full"
+          >
             <AccordionItem value="monitorSettings">
               <AccordionTrigger className="flex-row-reverse justify-end gap-4 hover:no-underline">
                 Monitor settings

--- a/client/app/components/module/monitor/form/schema.ts
+++ b/client/app/components/module/monitor/form/schema.ts
@@ -134,8 +134,11 @@ export const getMonitorFormDefaultValues = (
   urlMonitor: "",
   monitorSettings: {
     monitor_interval: 2,
-    request_timeout: 3,
-    grace_time: 3,
+    // Slider steps, not seconds: 1 = 30s, 2 = 1min, 3 = 5min (MONITOR_INTERVAL).
+    // Timeout and grace default to 30s because a new monitor almost always needs
+    // them set; the interval stays at 1min.
+    request_timeout: 1,
+    grace_time: 1,
     check_ssl_errors: false,
     ssl_expiry_reminders: false,
     domain_expiry_reminders: false,

--- a/client/app/components/module/monitor/form/use-monitor-form-controller.ts
+++ b/client/app/components/module/monitor/form/use-monitor-form-controller.ts
@@ -63,17 +63,25 @@ export const useMonitorFormController = ({
 
   const { data: monitorDetails } = useGetMonitorById(itemId || "");
 
-  const initialValues = useMemo(() => {
+  // react-hook-form seeds its state from `defaultValues` and only reconciles `values` in
+  // an effect, so the two have to be chosen together: a single shared seed would either
+  // flash the add defaults on the edit form's first render, or flash the edit fallback on
+  // the add form's. Each mode therefore supplies its own pair.
+  const { defaultValues, values } = useMemo(() => {
     if (isEditMode) {
-      return toFormValuesFromMonitorDetails(monitorDetails?.data);
+      return {
+        defaultValues: toFormValuesFromMonitorDetails(),
+        values: toFormValuesFromMonitorDetails(monitorDetails?.data),
+      };
     }
 
-    return getMonitorFormDefaultValues();
+    const addDefaults = getMonitorFormDefaultValues();
+    return { defaultValues: addDefaults, values: addDefaults };
   }, [isEditMode, monitorDetails?.data]);
 
   const form = useForm<MonitorFormValues>({
-    defaultValues: getMonitorFormDefaultValues(),
-    values: initialValues,
+    defaultValues,
+    values,
     resolver: zodResolver(monitorFormSchema),
     mode: "onChange",
   });

--- a/client/app/components/module/monitor/form/util.ts
+++ b/client/app/components/module/monitor/form/util.ts
@@ -22,6 +22,13 @@ type SubmitContext = {
 
 const DEFAULT_REQUEST_BODY = '{"key":"value"}';
 
+/**
+ * Slider step the edit form falls back to when a monitor has no saved timeout or
+ * grace value (step 3 = 5 minutes). Pinned here so that changing the *add* defaults
+ * in getMonitorFormDefaultValues cannot alter what the edit form shows.
+ */
+const EDIT_FALLBACK_TIMEOUT_STEP = 3;
+
 export const toMonitorSourceType = (sourceType: SourceType): MONITOR_SOURCE_TYPES => {
   if (sourceType === "deployed") return MONITOR_SOURCE_TYPES.DeployedServices;
   if (sourceType === "my-services") return MONITOR_SOURCE_TYPES.ExternalServices;
@@ -104,7 +111,15 @@ export const toFormValuesFromMonitorDetails = (
   monitorDetails?: IMonitorDetails,
 ): MonitorFormValues => {
   if (!monitorDetails) {
-    return getMonitorFormDefaultValues();
+    const defaults = getMonitorFormDefaultValues();
+    return {
+      ...defaults,
+      monitorSettings: {
+        ...defaults.monitorSettings,
+        request_timeout: EDIT_FALLBACK_TIMEOUT_STEP,
+        grace_time: EDIT_FALLBACK_TIMEOUT_STEP,
+      },
+    };
   }
 
   const { headerName, headerValue, jsonSwitcher } = getHeaderInfo(monitorDetails.customHttpHeaders);
@@ -118,8 +133,8 @@ export const toFormValuesFromMonitorDetails = (
     urlMonitor: monitorDetails.url || "",
     monitorSettings: {
       monitor_interval: toSliderStep(monitorDetails.intervalInSeconds, 2),
-      request_timeout: toSliderStep(monitorDetails.timeoutInSeconds, 3),
-      grace_time: toSliderStep(monitorDetails.gracePeriodInSeconds, 3),
+      request_timeout: toSliderStep(monitorDetails.timeoutInSeconds, EDIT_FALLBACK_TIMEOUT_STEP),
+      grace_time: toSliderStep(monitorDetails.gracePeriodInSeconds, EDIT_FALLBACK_TIMEOUT_STEP),
       check_ssl_errors: monitorDetails.checkSSLErrors || false,
       ssl_expiry_reminders: monitorDetails.sslExpiryReminders || false,
       domain_expiry_reminders: monitorDetails.domainExpiryReminders || false,


### PR DESCRIPTION
Closes #196 — SPEC: Add Monitor modal, default-open settings accordion + 30s defaults

Adding a monitor almost always means setting the request timeout or grace time, but the "Monitor settings" accordion started collapsed and both fields defaulted to 5 minutes. Now the accordion opens by default and both fields default to 30 seconds. The monitor interval is untouched at 1 minute. **Add only** — Edit keeps its collapsed-by-default accordion and its real saved values.

The headline change is two lines. The other two production edits exist to stop those two lines leaking into the Edit flow, which §8 freezes — and that turned out to be the whole substance of this ticket.

## Why the defaults needed fencing off

`getMonitorFormDefaultValues` is shared by both modes, and Edit reaches it by two routes I did not expect:

1. **`toFormValuesFromMonitorDetails(undefined)` returns it** whenever a monitor's details are unavailable. I first assumed that was a transient loading state; it isn't — if the details request *fails*, Edit would have shown Add's 30s indefinitely. Its fallback step is now pinned locally (`EDIT_FALLBACK_TIMEOUT_STEP`), reusing the value its own `toSliderStep` calls already passed, so the function is more internally consistent than before and the Add defaults cannot move it.

2. **`useForm`'s `defaultValues` fed Add's values into Edit's *first render*.** React Hook Form seeds state from `defaultValues` and only reconciles the `values` prop in an effect, so a single shared seed always flashes the wrong values in whichever mode doesn't own it. Verified empirically rather than reasoned about: a throwaway probe recording the value on every render showed `[1, 3]` before the fix.

Each mode now supplies its own `defaultValues`/`values` pair from the controller's existing mode branch. The resulting sequences are:

| | first render | settled |
|---|---|---|
| Add | 30s | 30s |
| Edit, details not yet available | 5min | 5min |
| Edit, details cached | 5min | the monitor's saved value |

That last row is exactly what `dev` does today. My first attempt seeded both from `initialValues`, which produced `[saved, saved]` — better UX, since it removes a flash of a value that isn't the monitor's — but it *was* a change to Edit's observable behaviour, which the ticket forbids. Review pushed back twice and supplied a form that fixes the leak without changing Edit at all, so that's what shipped. **If you'd prefer Edit to skip the placeholder flash, that's a small follow-up, not something this PR should have decided.**

## The interesting thing about testing this

`IntervalSliderField` renders **every** tick label — `30s`, `1min`, `5min`, `30min`, `1h` — as static spans, and shows no current-value text. So `getByText("30s")` is true regardless of the default: the obvious assertion would have "verified" precisely the thing this ticket changes while verifying nothing. Every value assertion instead reads the Radix thumb's `aria-valuenow`, scoped by label because both sliders in the accordion expose `role="slider"`.

I mutation-tested rather than trusting green — **six probes, all caught by the intended tests**:

| Mutation | Caught by |
|---|---|
| revert the timeout default to 5min | H2 + schema + payload + modal-reopen tests |
| remove the accordion `defaultValue` | H1–H5, C5 |
| apply default-open to Edit as well | C1, C2 |
| un-pin the Edit fallback | both `util.ts` fallback tests |
| revert the controller seed | the two first-render tests |
| make Add settle onto the 5min fallback | the three new controller tests |

That last probe came from review: my tests could all have passed while H2/H3/H5 failed in production, because the field tests build their own form and the payload tests call `getMonitorFormDefaultValues` directly — nothing connected the *real controller's* settled state to what a user submits. There are now controller-level tests that submit through `controller.submit` and assert `timeoutInSeconds: 30` / `gracePeriodInSeconds: 30` on the outgoing payload.

## Four existing tests changed

All deliberate, none to make a failure go away:

| Test | Why |
|---|---|
| `form-fields.test.tsx:109` | clicked the accordion to open it; it now starts open, so the click would collapse it and Radix unmounts the content |
| `form-fields.test.tsx:141` | same inversion |
| `form-fields.test.tsx:67` | the edit test set only `isEditMode`, leaving `mode: "add"`; the props are independent at the component boundary so both are now set |
| `util.test.ts:76` | asserted `toEqual(getMonitorFormDefaultValues())` for the no-details branch, which by design no longer matches; it now names the expected shape |

Dropping those two clicks removed the only coverage of *opening* a closed accordion — a disabled Edit trigger would then have passed everything, since C5 only exercises Add where it starts open. That coverage moved to the C1 Edit test, which asserts collapsed-then-clickable.

## Verification

- `npm run lint` — **0 errors**, 3 warnings, all pre-existing (verified identical at `HEAD` by stashing)
- `npm run build` — succeeded
- `npm test` — **315 passed, 0 failed**, 28 files
- Coverage — `schema.ts` 100%, `monitor-form-fields.tsx` 100%, `use-monitor-form-controller.ts` 96.9%, `util.ts` 96.3% (per-file line coverage, not a project total)
- Every H1–H5 and C1–C5 has a test that fails if the implementation is wrong.

**§9 is not fully satisfied: the §7 E2E walkthrough has not been run.** It needs a logged-in user against a live project's Monitor page, which this delivery loop does not provision. Steps 1–5 and 7 have equivalent unit coverage, and step 2's reopen-resets behaviour is covered by a test that drives the real `MonitorModal` with `open` toggled — chosen over a hand-rolled unmount so that a `forceMount` regression would actually fail it. Still genuinely browser-only: **step 6** (submit and confirm the persisted value) and **step 8** (configure a pre-existing monitor).

## Note on the ticket text

§3 says `mode` is "already threaded through `MonitorFormFields` props". It is declared and passed, but never destructured or used — the component branches on `isEditMode`. I gated on `isEditMode` to avoid a second source of truth, and left the unused prop alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
