### PR TITLE
feat: show paused state on the monitor table and details page

### DIFF
--- a/client/app/__tests__/module/alert/alert-action.test.tsx
+++ b/client/app/__tests__/module/alert/alert-action.test.tsx
@@ -23,6 +23,7 @@ vi.mock("react-router", async (o) => {
   return { ...actual, useNavigate: () => h.navigate };
 });
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import AlertAction from "@/components/module/alert/alert-action";
 import { QueryWrapper } from "../../test-utils";
 
@@ -101,5 +102,86 @@ describe("AlertAction", () => {
     await waitFor(() =>
       expect(h.toast).toHaveBeenCalledWith(expect.objectContaining({ variant: "destructive" })),
     );
+  });
+});
+
+// Pause/resume must leave both the table and the details page showing the new state, using the
+// invalidation that already exists rather than any new refetch logic (issue #197, H5).
+describe("AlertAction refreshes the views after pause and resume", () => {
+  beforeEach(() => {
+    // The suite above ends with `mockRejectedValue` (not `...Once`), which persists across
+    // describes, and clearAllMocks does not reset implementations. Without this the "nominal"
+    // pause and resume cases below would silently run the failure path and pass only because
+    // the invalidation sits in a `finally`.
+    h.updateReq.mockReset().mockResolvedValue({ isSuccess: true });
+    h.updateHealth.mockReset().mockResolvedValue({ isSuccess: true });
+    h.toast.mockReset();
+  });
+
+  const renderWithSpy = (props: Partial<React.ComponentProps<typeof AlertAction>> = {}) => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidate = vi.spyOn(client, "invalidateQueries").mockResolvedValue(undefined);
+    render(
+      <QueryClientProvider client={client}>
+        <AlertAction monitorId="m1" isActive name="Monitor" request projectKey="p1" {...props}>
+          <button>Actions</button>
+        </AlertAction>
+      </QueryClientProvider>
+    );
+    return invalidate;
+  };
+
+  const keysFrom = (invalidate: ReturnType<typeof renderWithSpy>) =>
+    invalidate.mock.calls.map(([arg]) => JSON.stringify((arg as { queryKey: unknown }).queryKey));
+
+  it.each([
+    ["Pause", true],
+    ["Resume", false],
+  ])("invalidates both list and detail queries after %s", async (label, isActive) => {
+    const invalidate = renderWithSpy({ isActive });
+    await userEvent.click(screen.getByRole("button", { name: "Actions" }));
+    await userEvent.click(await screen.findByText(label));
+    await userEvent.click(await screen.findByRole("button", { name: "Confirm" }));
+
+    await waitFor(() => expect(invalidate).toHaveBeenCalled());
+    // Prove this really is the success path, so the assertions below cannot be satisfied by a
+    // failed toggle that invalidated from its `finally`.
+    expect(h.toast).toHaveBeenCalledWith(expect.objectContaining({ variant: "success" }));
+    const keys = keysFrom(invalidate);
+    // The table reads the first two; the details page reads the third. Missing any one of them
+    // leaves one view showing the old paused/active state.
+    expect(keys).toContain(JSON.stringify(["health-monitor-list"]));
+    expect(keys).toContain(JSON.stringify(["monitor-list-by-id"]));
+    expect(keys).toContain(JSON.stringify(["get-monitor-by-id", "m1"]));
+  });
+
+  it("invalidates the same queries for a callback monitor", async () => {
+    // Both cases above use a request monitor, so moving the invalidation into that branch would
+    // leave callback monitors stale in every view and still pass the suite.
+    const invalidate = renderWithSpy({ isActive: true, request: false });
+    await userEvent.click(screen.getByRole("button", { name: "Actions" }));
+    await userEvent.click(await screen.findByText("Pause"));
+    await userEvent.click(await screen.findByRole("button", { name: "Confirm" }));
+
+    await waitFor(() => expect(h.updateHealth).toHaveBeenCalled());
+    const keys = keysFrom(invalidate);
+    expect(keys).toContain(JSON.stringify(["health-monitor-list"]));
+    expect(keys).toContain(JSON.stringify(["monitor-list-by-id"]));
+    expect(keys).toContain(JSON.stringify(["get-monitor-by-id", "m1"]));
+  });
+
+  it("still refreshes the views when the mutation fails", async () => {
+    // The invalidation sits in a `finally`, so a failed toggle also refetches. Asserted so the
+    // success-path tests above cannot be read as proving more than they do.
+    h.updateReq.mockReset().mockRejectedValue(new Error("boom"));
+    const invalidate = renderWithSpy({ isActive: true });
+    await userEvent.click(screen.getByRole("button", { name: "Actions" }));
+    await userEvent.click(await screen.findByText("Pause"));
+    await userEvent.click(await screen.findByRole("button", { name: "Confirm" }));
+
+    await waitFor(() => expect(invalidate).toHaveBeenCalled());
+    expect(keysFrom(invalidate)).toContain(JSON.stringify(["get-monitor-by-id", "m1"]));
   });
 });

--- a/client/app/__tests__/module/alert/alerts-list.test.tsx
+++ b/client/app/__tests__/module/alert/alerts-list.test.tsx
@@ -355,3 +355,102 @@ describe("AlertsList", () => {
     expect(down.container.querySelector("svg.lucide-arrow-down")).toBeTruthy();
   });
 });
+
+// Paused/active state in the Status column (issue #197)
+describe("AlertsList paused state", () => {
+  const renderRow = (over: Partial<AlertTree> = {}) =>
+    render(
+      <AlertsList
+        data={[alert(over)]}
+        isLoading={false}
+        sortQueryParams={sort}
+        onSortChange={vi.fn()}
+      />,
+      { wrapper: wrapper() }
+    );
+
+  it("shows a Paused badge instead of the progress bar when isActive is false", () => {
+    // H1, C1
+    renderRow({ isActive: false });
+    expect(screen.getByText("Paused")).toBeInTheDocument();
+    // The 24-hour bar is a health display; leaving it beside "Paused" would imply a
+    // current up/down state, which is what C1 forbids.
+    expect(screen.queryByTestId("progress")).toBeNull();
+  });
+
+  it("badges a paused monitor whose last known status was down", () => {
+    // Every other paused case here uses a stale "up" status, so an implementation that only
+    // took the paused branch when the monitor was last seen Up would slip through.
+    renderRow({ isActive: false, currentStatus: false });
+    expect(screen.getByText("Paused")).toBeInTheDocument();
+    expect(screen.queryByTestId("progress")).toBeNull();
+  });
+
+  it("keeps the progress bar and shows no badge when isActive is true", () => {
+    // H2
+    renderRow({ isActive: true, currentStatus: true });
+    expect(screen.getByTestId("progress")).toHaveAttribute("data-status", "true");
+    expect(screen.queryByText("Paused")).toBeNull();
+  });
+
+  it("keeps a down monitor's real status on the progress bar", () => {
+    // H2 again, from the other side. Without this an implementation that hardcoded
+    // status={true} would pass, because the existing down-state test asserts the Uptime
+    // arrow rather than the bar's own prop.
+    renderRow({ isActive: true, currentStatus: false });
+    expect(screen.getByTestId("progress")).toHaveAttribute("data-status", "false");
+  });
+
+  it("treats a row with no isActive field as active", () => {
+    // C4. The neighbouring AlertAction call resolves the same missing value with `?? false`,
+    // so copying that idiom here would badge every incomplete payload as Paused.
+    const row = alert();
+    delete (row as Partial<AlertTree>).isActive;
+    render(
+      <AlertsList data={[row]} isLoading={false} sortQueryParams={sort} onSortChange={vi.fn()} />,
+      { wrapper: wrapper() }
+    );
+    expect(screen.queryByText("Paused")).toBeNull();
+    expect(screen.getByTestId("progress")).toBeInTheDocument();
+  });
+
+  it("leaves the Uptime column untouched on a paused row", () => {
+    // C2. The ticket puts the Uptime column out of scope, so a paused row keeps both its
+    // formatted date and its arrow -- asserted so a later "tidy-up" that hides them fails.
+    const created = new Date("2026-01-05T09:00:00Z");
+    const { container } = renderRow({
+      isActive: false,
+      currentStatus: true,
+      lastIncidentAt: null as unknown as Date,
+      createdDate: created.toISOString(),
+    });
+    expect(screen.getByText("Paused")).toBeInTheDocument();
+    expect(container.querySelector("svg.lucide-arrow-up")).toBeTruthy();
+  });
+
+  it("follows refetched data when a row flips between paused and active", () => {
+    // H5 at the render level: no new refetch logic, the cell just reads the new value.
+    const { rerender } = renderRow({ isActive: true });
+    expect(screen.getByTestId("progress")).toBeInTheDocument();
+
+    rerender(
+      <AlertsList
+        data={[alert({ isActive: false })]}
+        isLoading={false}
+        sortQueryParams={sort}
+        onSortChange={vi.fn()}
+      />
+    );
+    expect(screen.getByText("Paused")).toBeInTheDocument();
+
+    rerender(
+      <AlertsList
+        data={[alert({ isActive: true })]}
+        isLoading={false}
+        sortQueryParams={sort}
+        onSortChange={vi.fn()}
+      />
+    );
+    expect(screen.queryByText("Paused")).toBeNull();
+  });
+});

--- a/client/app/__tests__/module/monitor/details/response-time.test.tsx
+++ b/client/app/__tests__/module/monitor/details/response-time.test.tsx
@@ -14,9 +14,12 @@ vi.mock("recharts", async () => {
     ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
       <div data-testid="responsive">{children}</div>
     ),
-    AreaChart: ({ children }: { children: React.ReactNode }) => (
-      <div data-testid="area-chart">{children}</div>
-    ),
+    AreaChart: ({ children, data }: { children: React.ReactNode; data?: unknown[] }) => {
+      // Capture the plotted series so tests can assert which points the component decided to
+      // draw, not merely that a chart rendered.
+      (globalThis as { __chartPoints?: unknown[] }).__chartPoints = data ?? [];
+      return <div data-testid="area-chart">{children}</div>;
+    },
     Area: () => <div data-testid="area" />,
     CartesianGrid: () => <div />,
     ReferenceLine: () => <div />,
@@ -126,5 +129,74 @@ describe("ResponseTime", () => {
     const option = await screen.findByText("Last 24 Hours");
     await userEvent.click(option);
     expect(setTimeRange).toHaveBeenCalledWith("24h");
+  });
+});
+
+// A paused monitor is not being checked, so the chart must not assert an up/down state at "now"
+// while the page shows a Paused badge (issue #197, C1).
+describe("ResponseTime while paused", () => {
+  const points = () => (globalThis as { __chartPoints?: { ts: number; status: number }[] }).__chartPoints ?? [];
+
+  it("plots a current status point while the monitor is active", () => {
+    render(<ResponseTime {...baseProps} currentStatus={false} isActive />);
+    const last = points().at(-1)!;
+    expect(last.status).toBe(0);
+  });
+
+  it("omits the current status point while the monitor is paused", () => {
+    render(<ResponseTime {...baseProps} currentStatus={false} isActive={false} />);
+    // Only the synthetic "now" reading disappears; the historical series is untouched, which is
+    // what keeps this consistent with C2 leaving incident history alone.
+    expect(points().some((p) => p.status === 0)).toBe(false);
+  });
+
+  it("omits it for a monitor with downtime history too", () => {
+    const withHistory = [
+      {
+        startTime: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+        endTime: new Date(Date.now() - 25 * 60 * 1000).toISOString(),
+      },
+    ] as unknown as typeof baseProps.data;
+
+    // Captured BEFORE render: the component anchors its own `now` at mount, so a timestamp read
+    // afterwards is always later than the point it plots there and `ts < now` would hold even
+    // for the very point this is meant to reject.
+    const beforeRender = Date.now();
+    render(<ResponseTime {...baseProps} data={withHistory} currentStatus={false} isActive={false} />);
+    // The last plotted point is a real recovery edge, not a "currently down" assertion at now.
+    expect(points().at(-1)!.ts).toBeLessThan(beforeRender);
+  });
+
+  it("defaults to plotting the current point when isActive is not supplied", () => {
+    render(<ResponseTime {...baseProps} currentStatus={false} />);
+    expect(points().at(-1)!.status).toBe(0);
+  });
+});
+
+describe("ResponseTime with an unresolved incident", () => {
+  const points = () => (globalThis as { __chartPoints?: { ts: number; status: number }[] }).__chartPoints ?? [];
+  const openIncident = () =>
+    [
+      { startTime: new Date(Date.now() - 20 * 60 * 1000).toISOString(), endTime: null },
+    ] as unknown as typeof baseProps.data;
+
+  it("plots the ongoing outage up to now while active", () => {
+    render(<ResponseTime {...baseProps} data={openIncident()} currentStatus={false} isActive />);
+    expect(points().filter((p) => p.status === 0).length).toBeGreaterThan(1);
+  });
+
+  it("does not claim the monitor is currently down while paused", () => {
+    // An open incident normalises its end to `now`, so guarding only the synthetic final point
+    // left this one asserting a live Down beside the Paused badge.
+    const beforeRender = Date.now();
+    render(
+      <ResponseTime {...baseProps} data={openIncident()} currentStatus={false} isActive={false} />
+    );
+    const down = points().filter((p) => p.status === 0);
+    expect(down.length).toBeGreaterThan(0); // the outage itself is still shown
+    // Compared against a pre-render timestamp, not Date.now(): the component's own `now` is
+    // earlier than any reading taken after render, so the naive comparison passed even when the
+    // offending point was present.
+    expect(down.every((p) => p.ts < beforeRender)).toBe(true);
   });
 });

--- a/client/app/__tests__/pages/monitor/details.test.tsx
+++ b/client/app/__tests__/pages/monitor/details.test.tsx
@@ -64,16 +64,28 @@ vi.mock("@/hooks/use-alerts", () => ({
 // Heavy children are covered by their own suites; stub them so this page test
 // stays focused on the page's own branches.
 vi.mock("@/components/module/monitor/details/response-time", () => ({
-  default: () => <div data-testid="response-time" />,
+  default: (props: { isActive?: boolean }) => {
+    // Capture the prop: an empty stub could not tell whether the page forwards paused state,
+    // so the C1 assertion below would have proved nothing.
+    lastResponseTimeIsActive = props.isActive;
+    return <div data-testid="response-time" />;
+  },
 }));
+
+let lastResponseTimeIsActive: boolean | undefined;
 vi.mock("@/components/module/monitor/details/monitor-card", () => ({
   default: () => <div data-testid="monitor-card" />,
 }));
 vi.mock("@/components/module/incident/incident-list", () => ({
-  default: (props: { data: unknown[] }) => (
-    <div data-testid="incident-list" data-count={props.data.length} />
-  ),
+  default: (props: { data: unknown[] }) => {
+    // Capture the actual data, not just its length: a count-only assertion would pass even
+    // if every incident had been replaced with a different object.
+    lastIncidentListData = props.data;
+    return <div data-testid="incident-list" data-count={props.data.length} />;
+  },
 }));
+
+let lastIncidentListData: unknown[] = [];
 vi.mock("@/components/module/alert/alert-action", () => ({
   default: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="alert-action">{children}</div>
@@ -136,6 +148,10 @@ describe("MonitorDetailsPage", () => {
     h.details.data.monitorIncidents = [];
     h.monitor.data.data.monitorSourceTypes = 0;
     h.monitor.data.data.currentStatus = true;
+    // Reset isActive too, or a paused / field-deleted fixture leaks into later tests and
+    // makes the active-state assertions order-dependent.
+    h.monitor.data.data.isActive = true;
+    lastIncidentListData = [];
   });
 
   it("renders the skeleton while any query is loading", () => {
@@ -194,5 +210,129 @@ describe("MonitorDetailsPage", () => {
     const viewAll = screen.getByText("View all incidents");
     await userEvent.click(viewAll);
     expect(h.navigate).toHaveBeenCalledWith("/scoped/monitor/incidents/m1");
+  });
+});
+
+// Paused/active state on the Current Status card (issue #197)
+describe("MonitorDetailsPage paused state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.details.isLoading = false;
+    h.monitor.isLoading = false;
+    h.downtime.isLoading = false;
+    h.details.data.monitorIncidents = [];
+    h.monitor.data.data.monitorSourceTypes = 0;
+    h.monitor.data.data.currentStatus = true;
+    h.monitor.data.data.isActive = true;
+    lastIncidentListData = [];
+    lastResponseTimeIsActive = undefined;
+  });
+
+  const statusCard = () => screen.getByText("Current Status").closest("div")!;
+
+  it("shows a Paused badge on the Current Status card when isActive is false", () => {
+    // H3
+    h.monitor.data.data.isActive = false;
+    renderPage();
+    expect(screen.getByText("Paused")).toBeInTheDocument();
+  });
+
+  it("drops every health signal from the card while paused", () => {
+    // C1. Asserting only that the "Currently up for ..." line disappears would still pass an
+    // implementation that showed "Paused" next to the up/down word in green.
+    h.monitor.data.data.isActive = false;
+    h.monitor.data.data.currentStatus = true;
+    const { container } = renderPage();
+
+    expect(screen.queryByText(/Currently (up|down) for/)).toBeNull();
+    const card = statusCard();
+    expect(card.textContent).not.toMatch(/\b(up|down)\b/i);
+    expect(container.querySelector(".text-green-500")).toBeNull();
+    expect(container.querySelector(".border-l-green-500")).toBeNull();
+    expect(container.querySelector(".border-l-red-500")).toBeNull();
+    expect(container.querySelector(".border-l-muted")).toBeTruthy();
+  });
+
+  it("shows Paused for a monitor whose last known status was down", () => {
+    // Same reasoning as the table: without this, a branch keyed on the stale status would pass.
+    h.monitor.data.data.isActive = false;
+    h.monitor.data.data.currentStatus = false;
+    renderPage();
+    expect(screen.getByText("Paused")).toBeInTheDocument();
+    expect(screen.queryByText(/Currently (up|down) for/)).toBeNull();
+  });
+
+  it("keeps the existing up/down status when isActive is true", () => {
+    // H4
+    renderPage();
+    expect(screen.queryByText("Paused")).toBeNull();
+    expect(screen.getByText(/Currently up for/)).toBeInTheDocument();
+  });
+
+  it("treats a missing isActive as active", () => {
+    // C4. `?? true` at the call site, not the `?? false` used for the action menu.
+    delete (h.monitor.data.data as { isActive?: boolean }).isActive;
+    renderPage();
+    expect(screen.queryByText("Paused")).toBeNull();
+    expect(screen.getByText(/Currently up for/)).toBeInTheDocument();
+  });
+
+  it("leaves incident history untouched while paused", () => {
+    // C2. Compares the forwarded data itself, since a count-only check would pass even if
+    // every incident had been swapped for a different object.
+    const incidents = [{ itemId: "i1" }, { itemId: "i2" }];
+    h.details.data.monitorIncidents = incidents;
+    h.monitor.data.data.isActive = false;
+    renderPage();
+
+    expect(screen.getByText("Paused")).toBeInTheDocument();
+    expect(lastIncidentListData).toEqual(incidents);
+  });
+
+  it("tells the Status Overview chart the monitor is paused", () => {
+    // C1. ResponseTime plots a current up/down point at "now"; without this the page would
+    // show "Paused" and a live Down reading at the same time.
+    h.monitor.data.data.isActive = false;
+    renderPage();
+    expect(screen.getByTestId("response-time")).toBeInTheDocument();
+    expect(lastResponseTimeIsActive).toBe(false);
+  });
+
+  it("tells the chart the monitor is active when it is", () => {
+    renderPage();
+    expect(lastResponseTimeIsActive).toBe(true);
+  });
+
+  it("tells the chart to treat a missing isActive as active", () => {
+    // C4 reaches the chart too, not just the badge.
+    delete (h.monitor.data.data as { isActive?: boolean }).isActive;
+    renderPage();
+    expect(lastResponseTimeIsActive).toBe(true);
+  });
+
+  it("follows refetched data when the monitor flips between paused and active", () => {
+    // H5 at the render level.
+    const { rerender } = renderPage();
+    expect(screen.getByText(/Currently up for/)).toBeInTheDocument();
+
+    const again = () =>
+      rerender(
+        <MemoryRouter initialEntries={["/app/m1/monitor/m1"]}>
+          <Routes>
+            <Route path="/app/:itemId/monitor/:id" element={<MonitorDetailsPage />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+    h.monitor.data.data.isActive = false;
+    again();
+    expect(screen.getByText("Paused")).toBeInTheDocument();
+
+    // And back again -- without the return leg a sticky paused state would pass every other
+    // assertion here while leaving the page Paused after a Resume.
+    h.monitor.data.data.isActive = true;
+    again();
+    expect(screen.queryByText("Paused")).toBeNull();
+    expect(screen.getByText(/Currently up for/)).toBeInTheDocument();
   });
 });

--- a/client/app/components/module/alert/alerts-list.tsx
+++ b/client/app/components/module/alert/alerts-list.tsx
@@ -2,6 +2,7 @@ import type { SortValue } from "@seliseblocks/genesis-os/components";
 import { FilterControls } from "@seliseblocks/genesis-os/components";
 import { TableLoadingSkeleton } from "@seliseblocks/genesis-os/components";
 import {
+  Badge,
   ScrollArea,
   ScrollBar,
   Table,
@@ -213,9 +214,21 @@ export function AlertsList({ data, isLoading, sortQueryParams, onSortChange }: A
         cell: ({ row }) => {
           const incidentList = row.original.incidentSummaries;
           const status = row.original.currentStatus;
+          // Strictly `=== false`, not `!isActive`: a row whose payload omits the field must read
+          // as active. The AlertAction call below uses `?? false` for the opposite reason -- see
+          // its own comment -- so the two defaults differ on purpose.
+          const isPaused = row.original.isActive === false;
           return (
             <div className="flex justify-start mt-3">
-              <ProgressBar incidents={incidentList} status={status} />
+              {isPaused ? (
+                // Replaces the bar rather than sitting beside it: 24 hours of green/red is a
+                // health display, and health is not meaningful while a monitor is paused.
+                <Badge variant="secondary" className="w-fit">
+                  Paused
+                </Badge>
+              ) : (
+                <ProgressBar incidents={incidentList} status={status} />
+              )}
             </div>
           );
         },

--- a/client/app/components/module/monitor/details/response-time.tsx
+++ b/client/app/components/module/monitor/details/response-time.tsx
@@ -26,6 +26,12 @@ type ResponseTimeProps = {
   timeRange: string;
   setTimeRange: (value: string) => void;
   currentStatus: boolean;
+  /**
+   * Whether the monitor is still being checked. A paused monitor has no current health, so the
+   * chart stops at its last real observation instead of asserting an up/down state at "now".
+   * Defaults to true so existing callers are unaffected.
+   */
+  isActive?: boolean;
   request: boolean;
 };
 
@@ -77,6 +83,7 @@ const ResponseTime = ({
   interval,
   timeout,
   currentStatus,
+  isActive = true,
   request,
 }: ResponseTimeProps) => {
   // Anchor the window at mount so the render stays pure (no Date.now() call in
@@ -128,7 +135,7 @@ const ResponseTime = ({
     pts.push({ ts: rangeStart, status: 1 });
 
     if (!downtimes || !Array.isArray(downtimes) || downtimes.length === 0) {
-      pts.push({ ts: now, status: currentStatus ? 1 : 0 });
+      if (isActive) pts.push({ ts: now, status: currentStatus ? 1 : 0 });
       return pts.sort((a, b) => a.ts - b.ts);
     }
 
@@ -157,21 +164,27 @@ const ResponseTime = ({
         duration: Math.round((e - s) / 1000),
       });
 
-      // downtime end
-      pts.push({
-        ts: e,
-        status: 0,
-        startTime: s,
-        endTime: e,
-        duration: Math.round((e - s) / 1000),
-      });
+      // downtime end. An unresolved incident normalises its end to `now` above, so while paused
+      // this point would assert "currently down" just as the synthetic final point would -- the
+      // guard has to cover both. The incident's start is still plotted, so the chart shows it
+      // went down and then observation stopped.
+      if (isActive || e < now) {
+        pts.push({
+          ts: e,
+          status: 0,
+          startTime: s,
+          endTime: e,
+          duration: Math.round((e - s) / 1000),
+        });
+      }
 
       // push one tick immediately after downtime to transition back to UP
       if (e + 1 <= now) pts.push({ ts: e + 1, status: 1 });
     }
 
-    // final point at now
-    pts.push({ ts: now, status: currentStatus ? 1 : 0 });
+    // final point at now -- skipped while paused: nothing is being checked, so plotting a
+    // current up/down here would contradict the Paused badge on the same page.
+    if (isActive) pts.push({ ts: now, status: currentStatus ? 1 : 0 });
 
     // dedupe by timestamp keeping last pushed (so transitions behave correctly)
     const map = new Map<number, ChartPoint>();
@@ -179,7 +192,7 @@ const ResponseTime = ({
     const final = Array.from(map.values()).sort((a, b) => a.ts - b.ts);
 
     return final;
-  }, [downtimes, rangeStart, now, currentStatus]);
+  }, [downtimes, rangeStart, now, currentStatus, isActive]);
 
   return (
     <Card className="mb-6 border-none p-0 shadow-none">

--- a/client/app/pages/monitor/details.tsx
+++ b/client/app/pages/monitor/details.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { BackIconButton } from "@/components/common/back-buttons";
-import { Button, Skeleton } from "@/components/core";
+import { Badge, Button, Skeleton } from "@/components/core";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/core/card/card";
 import { Separator } from "@/components/core/separator/separator";
 import AlertAction from "@/components/module/alert/alert-action";
@@ -28,6 +28,13 @@ interface MonitorSummaryProps {
   status: boolean;
   incident: Date;
   createdAt: string;
+  /**
+   * Whether the monitor is running. Typed plain `boolean` on purpose: the API model declares
+   * `isActive` as the literal `true`, so a `=== false` comparison against it directly would be a
+   * no-overlap error. The call site resolves it with `?? true`, which also gives C4's default --
+   * unexpected data reads as active, never as a false "Paused".
+   */
+  isActive: boolean;
 }
 
 const MonitorDetailsSkeleton = () => {
@@ -89,7 +96,7 @@ const getBorderColorClass = (index: number) => {
   return "border-l-chart-purple";
 };
 
-const MonitorSummary = ({ data, status, incident, createdAt }: MonitorSummaryProps) => {
+const MonitorSummary = ({ data, status, incident, createdAt, isActive }: MonitorSummaryProps) => {
   const toMilliseconds = (value: string): number => Number.parseInt(value, 10) * 24 * 60 * 60 * 1000;
   const [now] = useState(() => Date.now());
   const incidentDate = new Date(incident);
@@ -102,26 +109,42 @@ const MonitorSummary = ({ data, status, incident, createdAt }: MonitorSummaryPro
     <div className="my-6 flex w-full flex-col gap-4 md:flex-row md:gap-10">
       {data.map((item, index) => {
         if (item.type === "status") {
+          // Paused monitors are not being checked, so up/down says nothing true about them.
+          // Everything that encodes health here -- the border, the text colour, the status word
+          // and the "Currently up for ..." line -- drops out together rather than leaving a
+          // green card that also says "Paused".
+          const isPaused = isActive === false;
+
           return (
             <Card
               key={`status-${index}`} //nosonar
               className={`flex flex-1 flex-col rounded-md border-0 border-l-8 shadow-none ${
-                status ? "border-l-green-500" : "border-l-red-500"
+                isPaused ? "border-l-muted" : status ? "border-l-green-500" : "border-l-red-500"
               } bg-transparent py-2 pl-4`}
             >
               <CardTitle className="text-base font-medium">Current Status</CardTitle>
               <CardContent className="mt-3 flex flex-col gap-3">
-                <span
-                  className={`text-xl font-semibold capitalize ${
-                    status ? "text-green-500" : "text-red-500"
-                  }`}
-                >
-                  {item.status}
-                </span>
-                <span className="text-xs font-medium text-medium-emphasis">
-                  {" "}
-                  Currently {status ? "up" : "down"} for {incidentDuration}
-                </span>
+                {isPaused ? (
+                  // w-fit: Badge is a block-level flex element and this column is flex-col, so
+                  // without it the badge stretches into a full-width strip.
+                  <Badge variant="secondary" className="w-fit">
+                    Paused
+                  </Badge>
+                ) : (
+                  <>
+                    <span
+                      className={`text-xl font-semibold capitalize ${
+                        status ? "text-green-500" : "text-red-500"
+                      }`}
+                    >
+                      {item.status}
+                    </span>
+                    <span className="text-xs font-medium text-medium-emphasis">
+                      {" "}
+                      Currently {status ? "up" : "down"} for {incidentDuration}
+                    </span>
+                  </>
+                )}
               </CardContent>
             </Card>
           );
@@ -258,6 +281,10 @@ const MonitorDetailsPage = () => {
             <MonitorSummary
               data={summaryData}
               status={monitorData?.data?.currentStatus ?? false}
+              // `?? true`, not `?? false`: unexpected data must read as active (C4). The
+              // AlertAction call above deliberately keeps `?? false` -- it sends `!isActive`, so
+              // that default offers to activate rather than to pause a possibly-running monitor.
+              isActive={monitorData?.data?.isActive ?? true}
               incident={
                 monitorData?.data?.lastIncidentAt
                   ? new Date(monitorData?.data?.lastIncidentAt)
@@ -275,6 +302,9 @@ const MonitorDetailsPage = () => {
               timeRange={timeRange}
               setTimeRange={setTimeRange}
               currentStatus={monitorData?.data?.currentStatus || false}
+              // Same `?? true` default as the status card: the chart must not assert a current
+              // up/down state while the page is showing "Paused".
+              isActive={monitorData?.data?.isActive ?? true}
             />
             <Separator orientation="horizontal" className="mb-6" />
             <div className="flex flex-col gap-5">


### PR DESCRIPTION
Closes #197 — SPEC: Show paused/active state on Monitor table and details page

Pausing a monitor set `isActive=false` correctly, but nothing displayed it: the flag only picked the "Pause"/"Resume" menu label, so a paused monitor looked identical to a running one **and kept showing an up/down health state it was no longer measuring**. The table's Status column and the details Current Status card now show a **Paused** badge, and the Status Overview chart stops asserting a current reading.

## Health signals go together, or not at all

A paused monitor isn't being checked, so anything claiming to know its health has to disappear at once — otherwise you get a green card that also says "Paused". On the details card that's the status word, the "Currently up for …" line, the text colour and the left border. In the table it's the 24-bar chart, replaced rather than sat beside.

**The chart needed the same treatment, and this is the part worth reviewing.** `ResponseTime` plots a synthetic point at "now" from `currentStatus`, so a paused monitor showed **"Paused" and a live Down reading on the same screen**. It gains an optional `isActive` prop that suppresses that point.

There were two ways to assert a current state, not one. Guarding the obvious synthetic point still left an **unresolved incident** (`endTime: null`) normalising its end to `now` and plotting Down there. Both are guarded now. The incident's *start* is still plotted, so the chart reads as "it went down, then we stopped watching" rather than pretending the outage resolved.

## Missing `isActive` is treated as active — and deliberately differs from its neighbours

C4 requires unexpected data to render as active. The condition is `=== false` throughout, never `!isActive`, and on the details page the value crosses in as `?? true` because `IMonitorDetails` declares `isActive` as the literal `true` (and `currentStatus` as literal `false` — the same mistake twice), which makes a direct comparison a no-overlap error. **I have not corrected those model types**: a real bug, but a shared type with other consumers, and this is a display-only ticket.

**The `AlertAction` / `NotificationModal` call sites keep `?? false`, so with missing data the badge says active while the dropdown says "Resume".** That inconsistency is intentional. `AlertAction` sends `isActive: !isActive`, so today's default offers to *activate* an unknown monitor; flipping it for consistency would offer to *pause* a possibly-running one. Consistency would buy a strictly worse failure, and C4's wording scopes it to the indicator. Flagged so you can overrule it knowingly.

## What deliberately still shows health

Per C2, a paused row keeps its **Uptime date and arrow**, and incident history is untouched. Both are asserted, so a later tidy-up that hides them fails.

## Verification

- `npm run lint` — **0 errors**, 3 warnings, all pre-existing (the one now at `alerts-list.tsx:269` was at `:256` before this change — same warning, shifted by the added lines; verified by stashing)
- `npm run build` — succeeded
- `npm test` — **342 passed, 0 failed** (313 at `dev`)
- Per-file coverage: `alerts-list.tsx` 96.2%, `details.tsx` 98.5%, `response-time.tsx` 100%

**Twelve mutation probes, all caught.** Two are worth naming because they exposed *test* bugs rather than code bugs:

- The H5 invalidation tests silently inherited a `mockRejectedValue` (not `…Once`) from an earlier suite, so the "successful pause/resume" cases were running the **failure** path and passing only because invalidation sits in a `finally`. They now reset their own mocks and assert the success toast.
- My first open-incident assertion compared against `Date.now()` read *after* render, but the component anchors its own `now` at mount — so `ts < now` held even for the offending point. The probe passed when it should have failed, which is how I found it. Now anchored to a pre-render timestamp.

Also covered: an active-but-**down** row (so a hardcoded `status={true}` fails), paused-**and**-down cases in both renderers (so a branch keyed on the stale status fails), the resume leg of the flip (so a sticky paused state fails), and callback monitors in the invalidation tests (so moving invalidation into the request branch fails).

**Not done: the §7 walkthrough.** It needs a live logged-in environment this loop doesn't provision. Every step has a unit equivalent — including the real pause/resume path, via the invalidation assertions — but the browser run itself is outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
