### PR TITLE
[#201] SPEC — Fetch Repository List via Internal ReleaseDriver Service in Blocks Monitor

### DIFF
--- a/client/app/__tests__/hooks/use-alerts.test.tsx
+++ b/client/app/__tests__/hooks/use-alerts.test.tsx
@@ -13,6 +13,7 @@ vi.mock("@/services/alerts.service", () => {
       deleteSingleMonitor: ok(),
       getHealthMonitorList: ok(),
       getMonitorListById: ok(),
+      getReposList: ok(),
       isExternalServiceConfigured: ok(),
       getMonitorDetails: ok(),
       getMonitorById: ok(),
@@ -48,6 +49,36 @@ describe("use-alerts queries", () => {
     );
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(alertsService.getHealthMonitorList).toHaveBeenCalled();
+  });
+
+  it("useGetReposList fetches the repository list", async () => {
+    // H3, the half the controller test cannot show: that the hook actually reaches the service.
+    const { result } = renderHook(() => hooks.useGetReposList("t-1"), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(alertsService.getReposList).toHaveBeenCalled();
+  });
+
+  it("useGetReposList stays disabled without a scope", async () => {
+    const { result } = renderHook(() => hooks.useGetReposList(""), { wrapper });
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(alertsService.getReposList).not.toHaveBeenCalled();
+  });
+
+  it("useGetReposList refetches when the tenant changes instead of serving cached repos", async () => {
+    // The reason projectKey is in the query key at all. QueryClient runs a 60s staleTime, so a
+    // scope-free key would hand tenant t-2 the repositories fetched for t-1 - which then get
+    // compared against t-2's monitor list. Asserting a SECOND call is the whole point; a test that
+    // only checked the first would pass with the leak in place.
+    const { result, rerender } = renderHook(({ scope }: { scope: string }) => hooks.useGetReposList(scope), {
+      wrapper,
+      initialProps: { scope: "t-1" },
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(alertsService.getReposList).toHaveBeenCalledTimes(1);
+
+    rerender({ scope: "t-2" });
+
+    await waitFor(() => expect(alertsService.getReposList).toHaveBeenCalledTimes(2));
   });
 
   it("useGetHealthMonitorList stays disabled without a project key", async () => {

--- a/client/app/__tests__/module/monitor/form/controller.test.tsx
+++ b/client/app/__tests__/module/monitor/form/controller.test.tsx
@@ -9,7 +9,10 @@ const h = vi.hoisted(() => ({
   monitorById: { data: undefined as unknown },
   repoMonitorList: { data: [] as unknown[] },
   externalConfig: { data: null as unknown },
-  envRepos: { data: [] as unknown[], isLoading: false },
+  envRepos: { data: [] as unknown[], isLoading: false, isError: false },
+  reposListSpy: vi.fn(),
+  monitorListByIdSpy: vi.fn(),
+  legacyEnvReposSpy: vi.fn(),
   services: { data: [] as unknown[], isLoading: false },
   navigate: vi.fn(),
   showError: vi.fn(),
@@ -25,16 +28,33 @@ vi.mock("@/hooks/use-alerts", () => ({
   }),
   useUpdateHealth: () => ({ mutateAsync: h.updateHealthAsync, isPending: false }),
   useGetMonitorById: () => h.monitorById,
-  // controller destructures { data } then reads `.data` again → double-nested
-  useGetMonitorListById: () => ({ data: h.repoMonitorList }),
+  // controller destructures { data } then reads `.data` again → double-nested.
+  // Arguments are recorded: without that, the duplication test cannot tell a correctly scoped call
+  // from one made with the wrong tenant or repo, since the fixture comes back either way.
+  useGetMonitorListById: (projectKey: string, repoId: string) => {
+    h.monitorListByIdSpy(projectKey, repoId);
+    return { data: h.repoMonitorList };
+  },
   useIsExternalServiceConfigured: () => ({ data: h.externalConfig }),
+  // The repository list now comes from our own API. Fed from the same h.envRepos fixture the
+  // legacy mock used, so every pre-existing test in this file exercises the new path unchanged.
+  useGetReposList: (projectKey: string) => {
+    h.reposListSpy(projectKey);
+    return {
+      data: { data: h.envRepos.data },
+      isLoading: h.envRepos.isLoading,
+      isError: h.envRepos.isError,
+    };
+  },
 }));
 
 vi.mock("@seliseblocks/genesis-os/hooks", () => ({
-  useGetEnvRepositories: () => ({
-    data: { data: h.envRepos.data },
-    isLoading: h.envRepos.isLoading,
-  }),
+  // Deliberately still mocked, and deliberately spied: the point of this ticket is that the
+  // controller NEVER reaches blocks-logic for repositories. If the import came back, this records it.
+  useGetEnvRepositories: () => {
+    h.legacyEnvReposSpy();
+    return { data: { data: h.envRepos.data }, isLoading: h.envRepos.isLoading };
+  },
   useGetAllServices: () => ({
     data: { data: h.services.data },
     isLoading: h.services.isLoading,
@@ -317,5 +337,192 @@ describe("useMonitorFormController", () => {
       await result.current.submit(getMonitorFormDefaultValues("request"));
     });
     expect(h.addAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe("useMonitorFormController — repository source (#201)", () => {
+  const repo = (over: Record<string, unknown> = {}) => ({
+    itemId: "repo-123",
+    repoName: "my-app",
+    customDeploymentUrl: "https://custom.dev",
+    defaultDeploymentUrl: "https://default.internal",
+    repoUrl: "https://github.com/org/my-app",
+    ...over,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.monitorById.data = undefined;
+    h.repoMonitorList.data = [];
+    h.externalConfig.data = null;
+    h.envRepos.data = [];
+    h.envRepos.isLoading = false;
+    h.envRepos.isError = false;
+    h.services.data = [];
+    h.services.isLoading = false;
+  });
+
+  it("reads repositories from our own API and never from blocks-logic", async () => {
+    // H3. The negative assertion is the ticket: it is entirely possible to add the new hook and
+    // leave the old one in place, and every other test here would still pass.
+    h.envRepos.data = [repo()];
+
+    const { result } = render({ mode: "add", projectKey: "t-1" });
+
+    expect(h.reposListSpy).toHaveBeenCalledWith("t-1");
+    expect(h.legacyEnvReposSpy).not.toHaveBeenCalled();
+    expect(result.current.deployedRepos).toHaveLength(1);
+  });
+
+  it.each([
+    ["customDeploymentUrl first", {}, "https://custom.dev"],
+    ["defaultDeploymentUrl when custom is absent", { customDeploymentUrl: null }, "https://default.internal"],
+    [
+      "repoUrl when both deployment urls are absent",
+      { customDeploymentUrl: null, defaultDeploymentUrl: null },
+      "https://github.com/org/my-app",
+    ],
+    [
+      "empty string when the repo carries no url at all",
+      { customDeploymentUrl: null, defaultDeploymentUrl: null, repoUrl: null },
+      "",
+    ],
+  ])("prefills urlMonitor with %s", async (_label, over, expected) => {
+    // H4, walked one rung at a time. A single happy-path fixture passes even if the fallback order
+    // is reversed, which is the mistake worth catching here.
+    h.envRepos.data = [repo(over)];
+
+    const { result } = render({ mode: "add", projectKey: "t-1" });
+    act(() => result.current.setSelectedRepoId("repo-123"));
+
+    await waitFor(() => expect(result.current.form.getValues("urlMonitor")).toBe(expected));
+  });
+
+  it("still flags a duplicate monitor for a repo sourced from the new endpoint", async () => {
+    // H5. The duplication check reads a separate, still-tenant-scoped query; this proves the swap
+    // did not sever it.
+    h.envRepos.data = [repo()];
+    h.repoMonitorList.data = [{ itemId: "other-monitor" }];
+
+    const { result } = render({ mode: "add", projectKey: "t-1" });
+    act(() => result.current.setSourceType("deployed"));
+    act(() => result.current.setSelectedRepoId("repo-123"));
+
+    // Asserted through the user-visible message: repoDuplicate is internal and not returned.
+    await waitFor(() =>
+      expect(result.current.sourceError).toBe("A monitor already exists for this deployed repo."),
+    );
+    // And that the check was actually scoped to this tenant and this repo - the mock returns its
+    // fixture regardless of arguments, so without this the wiring could be wrong and still pass.
+    expect(h.monitorListByIdSpy).toHaveBeenLastCalledWith("t-1", "repo-123");
+  });
+
+  it("reports the loading state from the new hook", async () => {
+    // C3. These strings already existed; what is new is that they must be driven by the NEW hook's
+    // isLoading. If the swap dropped it, this is what fails.
+    h.envRepos.isLoading = true;
+
+    const { result } = render({ mode: "add", projectKey: "t-1" });
+    act(() => result.current.setSourceType("deployed"));
+
+    await waitFor(() => expect(result.current.sourceError).toBe("Loading repos..."));
+  });
+
+  it("prompts for a selection once an empty list has loaded", async () => {
+    // C4 and ticket example 2: empty is a loaded state, not a stuck loading one.
+    h.envRepos.data = [];
+    h.envRepos.isLoading = false;
+
+    const { result } = render({ mode: "add", projectKey: "t-1" });
+    act(() => result.current.setSourceType("deployed"));
+
+    await waitFor(() => expect(result.current.sourceError).toBe("Select a deployed repo."));
+  });
+
+  it("says the fetch failed rather than pretending there are no repos", async () => {
+    // C5, client half. Before this the 400/500 the endpoint returns was indistinguishable from an
+    // empty project: the user saw "Select a deployed repo." and was invited to choose from a list
+    // that never loaded. This is the assertion that makes the error path real rather than assumed.
+    h.envRepos.data = [];
+    h.envRepos.isLoading = false;
+    h.envRepos.isError = true;
+
+    const { result } = render({ mode: "add", projectKey: "t-1" });
+    act(() => result.current.setSourceType("deployed"));
+
+    await waitFor(() => expect(result.current.sourceError).toBe("Failed to get repos."));
+  });
+
+  it("surfaces a failure that arrives after the form is already open", async () => {
+    // The case the memo's dependency array actually governs. The test above sets isError before the
+    // first render, so it passed even while isReposError was missing from the deps and the message
+    // could never appear once the form was live. Lint caught that; this pins it.
+    h.envRepos.isError = false;
+
+    const { result, rerender } = renderHook(
+      ({ scope }: { scope: string }) =>
+        useMonitorFormController({ mode: "add", projectKey: scope }),
+      { initialProps: { scope: "t-1" } },
+    );
+    act(() => result.current.setSourceType("deployed"));
+    await waitFor(() => expect(result.current.sourceError).toBe("Select a deployed repo."));
+
+    h.envRepos.isError = true;
+    rerender({ scope: "t-1" });
+
+    await waitFor(() => expect(result.current.sourceError).toBe("Failed to get repos."));
+  });
+
+  it("leaves the my-services path on its own data source", async () => {
+    // Must-not-break: my-services is out of scope and must keep using useGetAllServices.
+    h.services.isLoading = true;
+
+    const { result } = render({ mode: "add", projectKey: "t-1" });
+    act(() => result.current.setSourceType("my-services"));
+
+    await waitFor(() => expect(result.current.sourceError).toBe("Loading services..."));
+  });
+
+  it("leaves external-URL monitors unblocked by the repository source", async () => {
+    // Must-not-break: an external URL depends on neither repos nor services, so no repo state
+    // should gate it.
+    const { result } = render({ mode: "add", projectKey: "t-1" });
+    act(() => result.current.setSourceType("none"));
+
+    await waitFor(() => expect(result.current.sourceError).toBeFalsy());
+    expect(result.current.isSourceBlocked).toBe(false);
+  });
+
+  it("KNOWN PRE-EXISTING DEFECT: a tenant switch leaves the repo selection in place", async () => {
+    // Documents current behaviour, not desired behaviour.
+    //
+    // The add form's `values` memo (use-monitor-form-controller.ts:70) depends only on
+    // [isEditMode, monitorDetails?.data], so nothing reseeds the form when projectKey changes:
+    // selectedRepoId and the prefilled urlMonitor survive, sourceError only checks that an id is
+    // present, and submission then pairs the NEW tenant with the OLD repo.
+    //
+    // This predates #201 and is independent of it - the same thing happens with the legacy
+    // useGetEnvRepositories(projectKey), because the stale value is form state rather than cache.
+    // #201 deliberately did not change form-seeding semantics under a data-source ticket. Asserted
+    // so that a future fix has to flip this deliberately instead of silently.
+    h.envRepos.data = [repo()];
+
+    const { result, rerender } = renderHook(
+      ({ scope }: { scope: string }) =>
+        useMonitorFormController({ mode: "add", projectKey: scope }),
+      { initialProps: { scope: "t-1" } },
+    );
+
+    act(() => result.current.setSelectedRepoId("repo-123"));
+    await waitFor(() => expect(result.current.form.getValues("urlMonitor")).toBe("https://custom.dev"));
+
+    // Tenant B: its repositories are fetched correctly...
+    h.envRepos.data = [repo({ itemId: "repo-999", repoName: "other-tenant-app" })];
+    rerender({ scope: "t-2" });
+
+    await waitFor(() => expect(h.reposListSpy).toHaveBeenCalledWith("t-2"));
+    // ...but tenant A's selection and URL are still sitting in the form.
+    expect(result.current.form.getValues("selectedRepoId")).toBe("repo-123");
+    expect(result.current.form.getValues("urlMonitor")).toBe("https://custom.dev");
   });
 });

--- a/client/app/__tests__/module/monitor/form/form-fields.test.tsx
+++ b/client/app/__tests__/module/monitor/form/form-fields.test.tsx
@@ -73,6 +73,29 @@ describe("MonitorFormFields", () => {
     ).toBeInTheDocument();
   });
 
+  it("says the list is empty only when it really loaded empty", () => {
+    // Baseline for the pair below: no repos, no error -> the empty note is correct.
+    render(<Harness overrides={{ sourceType: "deployed", deployedRepos: [], isLoadingRepos: false }} />);
+    expect(screen.getByText("No deployed repos available.")).toBeInTheDocument();
+  });
+
+  it("does not claim there are no repos when the fetch failed", () => {
+    // A failed request also leaves deployedRepos empty, so without the isReposError guard the form
+    // asserted "No deployed repos available." about a list it never received - alongside the
+    // controller's "Failed to get repos.", telling the user two different things at once.
+    render(
+      <Harness
+        overrides={{
+          sourceType: "deployed",
+          deployedRepos: [],
+          isLoadingRepos: false,
+          isReposError: true,
+        }}
+      />,
+    );
+    expect(screen.queryByText("No deployed repos available.")).toBeNull();
+  });
+
   it("shows the repo selector when source is deployed", () => {
     render(<Harness overrides={{ sourceType: "deployed" }} />);
     expect(screen.getByText("Select repo")).toBeInTheDocument();

--- a/client/app/__tests__/services/alerts.service.test.ts
+++ b/client/app/__tests__/services/alerts.service.test.ts
@@ -30,6 +30,14 @@ describe("alertsService", () => {
     expect(post).toHaveBeenCalledWith("/api/Monitor/SaveMonitor", { name: "x" });
   });
 
+  it("getReposList GETs exactly /api/Monitor/repos-list", async () => {
+    // The only test that can catch a server/client URL disagreement: the server-side route test
+    // cannot see the /api prefix, and every controller/hook test mocks this away. Exact equality,
+    // because a substring check would also accept the wrong path.
+    await alertsService.getReposList();
+    expect(get).toHaveBeenCalledWith("/api/Monitor/repos-list");
+  });
+
   it("updateSingleMonitor POSTs to UpdateMonitor", async () => {
     await alertsService.updateSingleMonitor({ itemId: "1" } as never);
     expect(post).toHaveBeenCalledWith("/api/Monitor/UpdateMonitor", {

--- a/client/app/components/module/monitor/form/add-monitor-form.tsx
+++ b/client/app/components/module/monitor/form/add-monitor-form.tsx
@@ -26,6 +26,7 @@ export function AddSingleMonitorForm({ itemId: _itemId, onSuccess }: Props) {
       deployedRepos={controller.deployedRepos}
       services={controller.services}
       isLoadingRepos={controller.isLoadingRepos}
+      isReposError={controller.isReposError}
       isLoadingServices={controller.isLoadingServices}
       isSubmitting={controller.isSubmitting}
       isEditMode={controller.isEditMode}

--- a/client/app/components/module/monitor/form/edit-monitor-form.tsx
+++ b/client/app/components/module/monitor/form/edit-monitor-form.tsx
@@ -27,6 +27,7 @@ export function EditSingleMonitorForm({ itemId, onSuccess }: Props) {
       deployedRepos={controller.deployedRepos}
       services={controller.services}
       isLoadingRepos={controller.isLoadingRepos}
+      isReposError={controller.isReposError}
       isLoadingServices={controller.isLoadingServices}
       isSubmitting={controller.isSubmitting}
       isEditMode={controller.isEditMode}

--- a/client/app/components/module/monitor/form/monitor-form-fields.tsx
+++ b/client/app/components/module/monitor/form/monitor-form-fields.tsx
@@ -65,6 +65,7 @@ type MonitorFormFieldsProps = {
   deployedRepos: RepoOption[];
   services: ServiceOption[];
   isLoadingRepos: boolean;
+  isReposError?: boolean;
   isLoadingServices: boolean;
   isSubmitting: boolean;
   isEditMode: boolean;
@@ -84,6 +85,7 @@ export const MonitorFormFields = ({
   deployedRepos,
   services,
   isLoadingRepos,
+  isReposError,
   isLoadingServices,
   isSubmitting,
   isEditMode,
@@ -97,7 +99,10 @@ export const MonitorFormFields = ({
   const httpMethod = form.watch("requestConfiguration.http_methods");
   const sendAsJson = form.watch("requestConfiguration.json_switcher");
 
-  const showEmptyRepos = !isLoadingRepos && deployedRepos.length === 0;
+  // A failed fetch also leaves deployedRepos empty, so without the isReposError guard the form
+  // renders "Failed to get repos." and "No deployed repos available." together - one of which is a
+  // guess. Only claim the list is empty when it actually loaded.
+  const showEmptyRepos = !isLoadingRepos && !isReposError && deployedRepos.length === 0;
   const showEmptyServices = !isLoadingServices && services.length === 0;
 
   return (

--- a/client/app/components/module/monitor/form/use-monitor-form-controller.ts
+++ b/client/app/components/module/monitor/form/use-monitor-form-controller.ts
@@ -2,6 +2,7 @@ import {
   useAddSingleMonitor,
   useGetMonitorById,
   useGetMonitorListById,
+  useGetReposList,
   useIsExternalServiceConfigured,
   useSaveHealth,
   useUpdateHealth,
@@ -15,7 +16,7 @@ import {
   toUpdateRequestPayload,
 } from "./util";
 import { ErrorTransformer } from "@seliseblocks/genesis-os/utils";
-import { useGetEnvRepositories, useGetAllServices } from "@seliseblocks/genesis-os/hooks";
+import { useGetAllServices } from "@seliseblocks/genesis-os/hooks";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMemo } from "react";
@@ -91,8 +92,13 @@ export const useMonitorFormController = ({
   const selectedRepoId = form.watch("selectedRepoId");
   const selectedServiceId = form.watch("selectedServiceId");
 
-  const { data: envRepositoriesResponse, isLoading: isLoadingRepos } =
-    useGetEnvRepositories(projectKey);
+  // Sourced from our own API rather than blocks-logic. Same { data: [...] } envelope, so
+  // deployedRepos, the selectedRepo lookup and the duplication check below are unchanged.
+  const {
+    data: envRepositoriesResponse,
+    isLoading: isLoadingRepos,
+    isError: isReposError,
+  } = useGetReposList(projectKey);
 
   const { data: servicesResponse, isLoading: isLoadingServices } = useGetAllServices({
     projectKey,
@@ -141,7 +147,12 @@ export const useMonitorFormController = ({
 
   const sourceError = useMemo(() => {
     if (sourceType === "deployed" && !selectedRepoId) {
-      return isLoadingRepos ? "Loading repos..." : "Select a deployed repo.";
+      if (isLoadingRepos) return "Loading repos...";
+      // A failed request must not read as "this project has no repositories": without this the
+      // 400/500 the endpoint returns is indistinguishable from an empty list, and the user is
+      // invited to pick from a list that never loaded.
+      if (isReposError) return "Failed to get repos.";
+      return "Select a deployed repo.";
     }
 
     if (sourceType === "my-services" && !selectedServiceId) {
@@ -162,6 +173,7 @@ export const useMonitorFormController = ({
     selectedRepoId,
     selectedServiceId,
     isLoadingRepos,
+    isReposError,
     isLoadingServices,
     repoDuplicate,
     serviceDuplicate,
@@ -287,6 +299,7 @@ export const useMonitorFormController = ({
     deployedRepos,
     services,
     isLoadingRepos,
+    isReposError,
     isLoadingServices,
     isEditMode,
     isSubmitting,

--- a/client/app/constants/endpoint.constant.ts
+++ b/client/app/constants/endpoint.constant.ts
@@ -37,6 +37,10 @@ export const DEPLOYMENT_ENDPOINTS = {
 } as const;
 
 export const ALERT_ENDPOINTS = {
+  // Kebab-case rather than the PascalCase action names used by its siblings: the server route
+  // escapes the controller's "[controller]/[action]" template for this one endpoint, matching the
+  // documented contract. Server-side route and this constant are each pinned by a test.
+  GET_REPOS_LIST: `${API_BASE}${MONITOR_SUBPATH}/repos-list`,
   SAVE_MONITOR: `${API_BASE}${MONITOR_SUBPATH}/SaveMonitor`,
   UPDATE_MONITOR: `${API_BASE}${MONITOR_SUBPATH}/UpdateMonitor`,
   DELETE_MONITOR: `${API_BASE}${MONITOR_SUBPATH}/DeleteMonitor`,

--- a/client/app/hooks/use-alerts.ts
+++ b/client/app/hooks/use-alerts.ts
@@ -111,6 +111,21 @@ export const useGetMonitorListById = (projectKey: string, repoId: string) => {
   });
 };
 
+/**
+ * Deployed repositories from our own API, replacing the browser's direct call to blocks-logic.
+ *
+ * `projectKey` (the selected tenant id) is NOT sent to the server - the driver scopes by the
+ * caller's token. It is part of the query key purely to partition the cache: QueryClient runs a
+ * 60s staleTime, so a shared key would keep serving the previous tenant's repositories for up to
+ * a minute after switching, and those would then be checked against the new tenant's monitors.
+ */
+export const useGetReposList = (projectKey: string) => {
+  return useQuery({
+    queryKey: ["repos-list", projectKey],
+    queryFn: () => alertsService.getReposList(),
+    enabled: !!projectKey,
+  });
+};
 export const useIsExternalServiceConfigured = (externalServiceId: string) => {
   return useQuery({
     queryKey: ["external-service-configured", externalServiceId],

--- a/client/app/models/alerts.model.ts
+++ b/client/app/models/alerts.model.ts
@@ -437,3 +437,19 @@ export interface IMonitorSummary {
   status?: "up" | "down";
   statusDuration?: string;
 }
+
+/** One deployed repository as returned by GET /api/Monitor/repos-list. */
+export interface IRepoListItem {
+  itemId: string;
+  repoName: string;
+  customDeploymentUrl?: string | null;
+  defaultDeploymentUrl?: string | null;
+  repoUrl?: string | null;
+}
+
+export interface IGetReposListResponse {
+  isSuccess: boolean;
+  statusCode?: number;
+  message?: string | null;
+  data: IRepoListItem[] | null;
+}

--- a/client/app/services/alerts.service.ts
+++ b/client/app/services/alerts.service.ts
@@ -8,6 +8,7 @@ import type {
   IGetAllIncidentListPayload,
   IGetHealthMonitorListPayload,
   IGetMonitorList,
+  IGetReposListResponse,
   IIncidentSummaryResponse,
   IMonitorIncidentListResponse,
   ISaveHealth,
@@ -31,6 +32,15 @@ class AlertsService {
   async deleteSingleMonitor(itemId: string) {
     const url = `${ALERT_ENDPOINTS.DELETE_MONITOR}?itemId=${encodeURIComponent(itemId)}`;
     return this.httpClient.delete<IAlertResponse<null>>(url);
+  }
+
+  /**
+   * Deployed repositories, served by our own API via IReleaseDriverService. Takes no parameters:
+   * the caller is identified by the auth token and the driver scopes the result server-side.
+   */
+  async getReposList() {
+    const url = ALERT_ENDPOINTS.GET_REPOS_LIST;
+    return this.httpClient.get<IGetReposListResponse>(url);
   }
 
   async getMonitorList(projectKey: string) {

--- a/server/Api/Api.csproj
+++ b/server/Api/Api.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="FluentValidation.AspNetCore" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="SeliseBlocks.ConfigurationDriver" />
+    <PackageReference Include="SeliseBlocks.ReleaseDriver.OS" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Alert.DomainService\Alert.DomainService.csproj" />

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -27,7 +27,7 @@
             Controller for managing monitor configurations, incidents, and response times.
             </summary>
         </member>
-        <member name="M:Api.Controllers.MonitorController.#ctor(DomainService.Monitor.Services.IMonitorConfigurationService,DomainService.Monitor.Services.IMonitorPingService,DomainService.Monitor.Services.IMonitorConfigurationRepoService,DomainService.Monitor.MonitorIncidentService.IMonitorIncidentService)">
+        <member name="M:Api.Controllers.MonitorController.#ctor(DomainService.Monitor.Services.IMonitorConfigurationService,DomainService.Monitor.Services.IMonitorPingService,DomainService.Monitor.Services.IMonitorConfigurationRepoService,DomainService.Monitor.MonitorIncidentService.IMonitorIncidentService,ReleaseDriver.IReleaseDriverService,Microsoft.Extensions.Logging.ILogger{Api.Controllers.MonitorController})">
             <summary>
             Initializes a new instance of the <see cref="T:Api.Controllers.MonitorController"/> class.
             </summary>
@@ -101,6 +101,25 @@
             <param name="startDate">The start date of the range (optional).</param>
             <param name="endDate">The end date of the range (optional).</param>
             <returns>The response time logs for the monitor.</returns>
+        </member>
+        <member name="M:Api.Controllers.MonitorController.GetReposList">
+            <summary>
+            Retrieves the deployed repository list for the caller, sourced from this API rather than
+            from the browser calling blocks-logic.
+            </summary>
+            <returns>The repository list, or a failure response if the release driver rejects it.</returns>
+            <remarks>
+            The route escapes the controller's "[controller]/[action]" template with "~/" on purpose.
+            A relative "repos-list" template would COMBINE with it and yield
+            Monitor/GetReposList/repos-list, which is not the documented contract; the route test in
+            MonitorControllerTests reads the generated route so this cannot regress silently.
+            </remarks>
+        </member>
+        <member name="F:Api.Controllers.MonitorController.FailedToGetRepos">
+            <summary>
+            The failure message the contract specifies. Public so the tests assert the exact string
+            rather than restating it and drifting from it.
+            </summary>
         </member>
         <member name="T:Program">
             <summary>

--- a/server/Api/Controllers/MonitorController.cs
+++ b/server/Api/Controllers/MonitorController.cs
@@ -2,8 +2,13 @@
 using DomainService.Monitor.MonitorIncidentService;
 using DomainService.Monitor.Services;
 using DomainService.Shared.Models;
+using System.Net;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+// The release driver namespace is deliberately NOT imported wholesale: it also defines a
+// `BaseApiResponse`, and importing it would make every existing `BaseApiResponse` in this file
+// ambiguous with DomainService.Shared.Models. Only the service interface is aliased in.
+using IReleaseDriverService = ReleaseDriver.IReleaseDriverService;
 
 namespace Api.Controllers
 {
@@ -18,6 +23,8 @@ namespace Api.Controllers
         private readonly IMonitorConfigurationRepoService _monitorConfigurationRepoService;
         private readonly IMonitorIncidentService _monitorIncidentService;
         private readonly IMonitorPingService _monitorPingService;
+        private readonly IReleaseDriverService _releaseDriverService;
+        private readonly ILogger<MonitorController> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MonitorController"/> class.
@@ -29,12 +36,16 @@ namespace Api.Controllers
             IMonitorConfigurationService monitorConfigurationService,
             IMonitorPingService monitorPingService,
             IMonitorConfigurationRepoService monitorConfigurationRepoService,
-            IMonitorIncidentService monitorIncidentService)
+            IMonitorIncidentService monitorIncidentService,
+            IReleaseDriverService releaseDriverService,
+            ILogger<MonitorController> logger)
         {
             _monitorConfigurationService = monitorConfigurationService;
             _monitorPingService = monitorPingService;
             _monitorConfigurationRepoService = monitorConfigurationRepoService;
             _monitorIncidentService = monitorIncidentService;
+            _releaseDriverService = releaseDriverService;
+            _logger = logger;
         }
 
         /// <summary>
@@ -182,5 +193,66 @@ namespace Api.Controllers
                 IsSuccess = true
             });
         }
+
+        /// <summary>
+        /// Retrieves the deployed repository list for the caller, sourced from this API rather than
+        /// from the browser calling blocks-logic.
+        /// </summary>
+        /// <returns>The repository list, or a failure response if the release driver rejects it.</returns>
+        /// <remarks>
+        /// The route escapes the controller's "[controller]/[action]" template with "~/" on purpose.
+        /// A relative "repos-list" template would COMBINE with it and yield
+        /// Monitor/GetReposList/repos-list, which is not the documented contract; the route test in
+        /// MonitorControllerTests reads the generated route so this cannot regress silently.
+        /// </remarks>
+        [Authorize]
+        [HttpGet("~/Monitor/repos-list")]
+        public async Task<IActionResult> GetReposList()
+        {
+            try
+            {
+                var result = await _releaseDriverService.GetReposListAsync();
+
+                if (result is null || !result.IsSuccess)
+                {
+                    _logger.LogError("Release driver reported failure retrieving the repository list.");
+                    return BadRequest(new BaseApiResponse
+                    {
+                        IsSuccess = false,
+                        StatusCode = HttpStatusCode.BadRequest,
+                        Message = FailedToGetRepos
+                    });
+                }
+
+                // Returned as-is: re-mapping into this repo's BaseApiResponse would risk silently
+                // dropping fields the driver adds to its own envelope.
+                return Ok(result);
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancellation is not a server fault - let it surface rather than reporting a
+                // failure the caller never caused.
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // GlobalExceptionHandlerMiddleware would already stop this from crashing the
+                // process; the catch exists to return the { isSuccess, message } shape the contract
+                // specifies instead of the middleware's generic body.
+                _logger.LogError(ex, "Unhandled failure retrieving the repository list.");
+                return StatusCode(StatusCodes.Status500InternalServerError, new BaseApiResponse
+                {
+                    IsSuccess = false,
+                    StatusCode = HttpStatusCode.InternalServerError,
+                    Message = FailedToGetRepos
+                });
+            }
+        }
+
+        /// <summary>
+        /// The failure message the contract specifies. Public so the tests assert the exact string
+        /// rather than restating it and drifting from it.
+        /// </summary>
+        public const string FailedToGetRepos = "Failed to get repos.";
     }
 }

--- a/server/Api/Program.cs
+++ b/server/Api/Program.cs
@@ -1,3 +1,4 @@
+using Blocks.Extensions.DependencyInjection;
 using Blocks.Genesis;
 using Microsoft.AspNetCore.Http.Features;
 using SeliseBlocks.ConfigurationDriver;
@@ -65,6 +66,14 @@ ApplyFrontendRuntimeSettings(builder.Configuration, wwwrootPath);
 
 
 Alert.DomainService.ServiceRegistry.AddApplicationServices(services);
+
+// Repository listing is served by our own API through IReleaseDriverService rather than by the
+// browser calling blocks-logic, so Monitor no longer depends on an outside service for it.
+// `vaultType` is the value already resolved above for ConfigureLogAndSecretsAsync - deliberately
+// reused so this does not introduce a second, independently-configured vault choice.
+// NOTE: this call reads the release driver's own secrets from that vault during startup, so the
+// API will not boot in an environment where those secrets are absent.
+await services.RegisterBlocksReleaseServicesAsync(vaultType);
 
 var app = builder.Build();
 

--- a/server/Directory.Packages.props
+++ b/server/Directory.Packages.props
@@ -9,7 +9,17 @@
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="MongoDB.Driver" Version="3.8.0" />
+    <!--
+      Genesis stays declared at 4.0.2, but note that Api does NOT run on it: ReleaseDriver.OS 4.0.1
+      requires a newer Genesis, so NuGet lifts Api's graph to SeliseBlocks.Genesis.OS 4.0.5, while
+      Worker and Alert.DomainService still resolve 4.0.2. Recorded rather than "fixed" by bumping
+      this line, because raising it centrally would also upgrade Worker - a separate process that
+      issue #201 does not touch and whose behaviour was never assessed against 4.0.5. The split is
+      safe: Api and Worker are separate processes, and Api's whole graph (including the
+      Alert.DomainService code it loads) runs on the single higher version.
+    -->
     <PackageVersion Include="SeliseBlocks.Genesis.OS" Version="4.0.2" />
+    <PackageVersion Include="SeliseBlocks.ReleaseDriver.OS" Version="4.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="FluentAssertions" Version="8.8.0" />

--- a/server/XUnitTest/Api/MonitorControllerTests.cs
+++ b/server/XUnitTest/Api/MonitorControllerTests.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Api.Controllers;
 using DomainService.Monitor.Entity;
@@ -7,6 +11,9 @@ using DomainService.Monitor.Services;
 using DomainService.Shared.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace XUnitTest.Api
@@ -17,9 +24,12 @@ namespace XUnitTest.Api
         private readonly Mock<IMonitorConfigurationRepoService> _configRepo = new();
         private readonly Mock<IMonitorIncidentService> _incidentService = new();
         private readonly Mock<IMonitorPingService> _pingService = new();
+        private readonly Mock<ReleaseDriver.IReleaseDriverService> _releaseDriver = new();
+        private readonly Mock<ILogger<MonitorController>> _logger = new();
 
         private MonitorController CreateSut() =>
-            new(_configService.Object, _pingService.Object, _configRepo.Object, _incidentService.Object);
+            new(_configService.Object, _pingService.Object, _configRepo.Object, _incidentService.Object,
+                _releaseDriver.Object, _logger.Object);
 
         private static T Body<T>(IActionResult result) =>
             (T)result.Should().BeOfType<OkObjectResult>().Subject.Value;
@@ -147,6 +157,231 @@ namespace XUnitTest.Api
             var body = Body<BaseApiResponse>(result);
             body.IsSuccess.Should().BeTrue();
             body.Data.Should().BeSameAs(config);
+        }
+
+        // ---------------------------------------------------------------------------------
+        // #201 — GET /Monitor/repos-list, backed by IReleaseDriverService.
+        // ---------------------------------------------------------------------------------
+
+        private static readonly System.Reflection.MethodInfo ReposListAction =
+            typeof(MonitorController).GetMethod(nameof(MonitorController.GetReposList))!;
+
+        [Fact]
+        public async Task GetReposList_DelegatesToDriverAndReturnsItsResponse()
+        {
+            // H1. Returned as-is rather than re-mapped, so the driver's own envelope fields survive.
+            var expected = new ReleaseDriver.BaseApiResponse { IsSuccess = true };
+            _releaseDriver.Setup(d => d.GetReposListAsync()).ReturnsAsync(expected);
+
+            var result = await CreateSut().GetReposList();
+
+            result.Should().BeOfType<OkObjectResult>()
+                  .Which.Value.Should().BeSameAs(expected);
+            _releaseDriver.Verify(d => d.GetReposListAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetReposList_EmptyListIsStillSuccess()
+        {
+            // Ticket example 2: no repos is a valid 200, not a failure.
+            var expected = new ReleaseDriver.BaseApiResponse { IsSuccess = true, Data = new List<object>() };
+            _releaseDriver.Setup(d => d.GetReposListAsync()).ReturnsAsync(expected);
+
+            var result = await CreateSut().GetReposList();
+
+            result.Should().BeOfType<OkObjectResult>();
+        }
+
+        [Fact]
+        public async Task GetReposList_WhenDriverReportsFailure_Returns400WithEnvelope()
+        {
+            // C2. The status code on the BODY is asserted as well as the HTTP status: BaseApiResponse
+            // defaults StatusCode, so a body-only check would pass while the payload was wrong.
+            _releaseDriver.Setup(d => d.GetReposListAsync())
+                          .ReturnsAsync(new ReleaseDriver.BaseApiResponse { IsSuccess = false });
+
+            var result = await CreateSut().GetReposList();
+
+            var bad = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+            bad.StatusCode.Should().Be(400);
+            var body = bad.Value.Should().BeOfType<BaseApiResponse>().Subject;
+            body.IsSuccess.Should().BeFalse();
+            body.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+            body.Message.Should().Be(MonitorController.FailedToGetRepos);
+        }
+
+        [Fact]
+        public async Task GetReposList_WhenDriverReturnsNull_Returns400()
+        {
+            // A null response is a failure, not a 200 carrying null.
+            _releaseDriver.Setup(d => d.GetReposListAsync()).ReturnsAsync((ReleaseDriver.BaseApiResponse)null!);
+
+            var result = await CreateSut().GetReposList();
+
+            result.Should().BeOfType<BadRequestObjectResult>();
+        }
+
+        [Fact]
+        public async Task GetReposList_WhenDriverThrows_Returns500AndLogsError()
+        {
+            // C5. Asserting only "an envelope came back and something was logged" would accept
+            // Ok({ isSuccess: false }), which contradicts the ticket's error contract - so the HTTP
+            // status, the body's own StatusCode and the log LEVEL are all pinned.
+            _releaseDriver.Setup(d => d.GetReposListAsync()).ThrowsAsync(new InvalidOperationException("driver down"));
+
+            var result = await CreateSut().GetReposList();
+
+            var obj = result.Should().BeOfType<ObjectResult>().Subject;
+            obj.StatusCode.Should().Be(500);
+            var body = obj.Value.Should().BeOfType<BaseApiResponse>().Subject;
+            body.IsSuccess.Should().BeFalse();
+            body.StatusCode.Should().Be(System.Net.HttpStatusCode.InternalServerError);
+            body.Message.Should().Be(MonitorController.FailedToGetRepos);
+
+            _logger.Verify(
+                l => l.Log(LogLevel.Error, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(),
+                           It.IsAny<Exception>(), (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()),
+                Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public async Task GetReposList_CancellationPropagates()
+        {
+            // C5b. A cancellation must not be laundered into a 500 the caller never caused.
+            // Narrower than it looks: GetReposListAsync takes no CancellationToken, so this proves
+            // an upstream cancellation is preserved - NOT that HttpContext.RequestAborted flows through.
+            _releaseDriver.Setup(d => d.GetReposListAsync()).ThrowsAsync(new OperationCanceledException());
+
+            var act = () => CreateSut().GetReposList();
+
+            await act.Should().ThrowAsync<OperationCanceledException>();
+        }
+
+        [Fact]
+        public void GetReposList_RouteEscapesTheControllerTemplate_AndResolvesToMonitorReposList()
+        {
+            // The route is the one thing a unit test can get wrong and still ship broken: a relative
+            // "repos-list" template COMBINES with the class-level "[controller]/[action]", giving
+            // Monitor/GetReposList/repos-list and a 404 against the documented URL.
+            //
+            // Combination is checked with the framework's own AttributeRouteModel.CombineTemplates
+            // rather than by reading the attribute string and trusting my own understanding of the
+            // rule - that is precisely the part worth not asserting from memory.
+            var template = ReposListAction.GetCustomAttributes(typeof(HttpGetAttribute), false)
+                                          .Cast<HttpGetAttribute>().Single().Template;
+
+            var controllerTemplate = typeof(MonitorController)
+                .GetCustomAttributes(typeof(RouteAttribute), true)
+                .Cast<RouteAttribute>().Single().Template;
+
+            AttributeRouteModel.CombineTemplates(controllerTemplate, template)
+                               .Should().Be("Monitor/repos-list");
+        }
+
+        [Fact]
+        public void GetReposList_RequiresAuthorization()
+        {
+            // C1, and the honest limit of it: this proves the action carries an authorize
+            // requirement, NOT that authentication middleware is present or correctly ordered. A
+            // real 401 would need an HTTP boundary, and standing one up here is not possible -
+            // Program.cs reads the vault before the builder even exists, and this project has
+            // neither Mvc.Testing nor TestHost.
+            ReposListAction.GetCustomAttributes(typeof(AuthorizeAttribute), true)
+                           .Should().NotBeEmpty();
+
+            // [Authorize] alone is not enough to assert: an [AllowAnonymous] alongside it wins, and
+            // the original test would have passed happily while the endpoint was open.
+            ReposListAction.GetCustomAttributes(true).OfType<IAllowAnonymous>()
+                           .Should().BeEmpty("AllowAnonymous would override the authorize requirement");
+            typeof(MonitorController).GetCustomAttributes(true).OfType<IAllowAnonymous>()
+                           .Should().BeEmpty("a controller-level AllowAnonymous would open every action");
+        }
+
+        [Fact]
+        public void ProgramRegistersTheReleaseDriverBeforeBuildingTheApp()
+        {
+            // H2, asserted structurally on purpose. RegisterBlocksReleaseServicesAsync reads its own
+            // vault secrets, so it cannot be invoked hermetically; and invoking it from a test would
+            // only show that the extension registers something - never that Program.cs calls it.
+            // Real post-registration resolution belongs in an environment smoke test.
+            var programPath = LocateProgramCs();
+            // Comments AND string literals are stripped first, so the search can only match
+            // executable code: a raw text search would be satisfied by the call appearing only in
+            // the comment that explains it, or assigned to a string.
+            var program = StripCommentsAndLiterals(File.ReadAllText(programPath));
+
+            var registerIndex = program.IndexOf("await services.RegisterBlocksReleaseServicesAsync(vaultType)",
+                                                StringComparison.Ordinal);
+            var buildIndex = program.IndexOf("builder.Build()", StringComparison.Ordinal);
+
+            registerIndex.Should().BeGreaterThan(-1, "the driver must be registered, awaited, with the vault type already resolved for ConfigureLogAndSecretsAsync");
+            buildIndex.Should().BeGreaterThan(-1);
+            registerIndex.Should().BeLessThan(buildIndex, "registration after Build() would never reach the container");
+        }
+
+        /// <summary>
+        /// Blanks out comments and string literals so the search below can only match executable
+        /// code. Without this the assertion is vacuous - satisfied by the call appearing solely in
+        /// a comment, or assigned to a string that is never executed.
+        /// </summary>
+        private static string StripCommentsAndLiterals(string source)
+        {
+            // Single left-to-right scan, no regex - every escaping layer between here and the file
+            // is another place to get it quietly wrong. Blanks out // line comments, /* */ block
+            // comments and "..." literals, so the search can only match executable code. Review
+            // cycle 2 was right that comments alone were not enough: `var marker = "await
+            // services.RegisterBlocksReleaseServicesAsync(vaultType)";` would have compiled,
+            // registered nothing, and passed.
+            var output = new System.Text.StringBuilder(source.Length);
+
+            for (var i = 0; i < source.Length; i++)
+            {
+                if (source[i] == '/' && i + 1 < source.Length && source[i + 1] == '/')
+                {
+                    while (i < source.Length && source[i] != '\n') i++;
+                    if (i < source.Length) output.Append('\n');
+                    continue;
+                }
+
+                if (source[i] == '/' && i + 1 < source.Length && source[i + 1] == '*')
+                {
+                    i += 2;
+                    while (i + 1 < source.Length && !(source[i] == '*' && source[i + 1] == '/')) i++;
+                    i++;
+                    output.Append(' ');
+                    continue;
+                }
+
+                if (source[i] == '"')
+                {
+                    i++;
+                    while (i < source.Length && source[i] != '"')
+                    {
+                        if (source[i] == '\\') i++;   // skip the escaped character
+                        i++;
+                    }
+                    output.Append("\"\"");
+                    continue;
+                }
+
+                output.Append(source[i]);
+            }
+
+            return output.ToString();
+        }
+
+        private static string LocateProgramCs()
+        {
+            for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir is not null; dir = dir.Parent)
+            {
+                var candidate = Path.Combine(dir.FullName, "Api", "Program.cs");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            throw new FileNotFoundException("could not locate Api/Program.cs above " + AppContext.BaseDirectory);
         }
     }
 }


### PR DESCRIPTION
Closes #201 — https://github.com/SELISEdigitalplatforms/blocks-monitor/issues/201

Adds `GET /api/Monitor/repos-list`, backed by `IReleaseDriverService` from `SeliseBlocks.ReleaseDriver.OS`, and points the Add Monitor form at it. Repository fetching no longer leaves the browser for `blocks-logic`.

## ⚠️ Deploy precondition — please confirm before this ships

`Program.cs` now **awaits** `RegisterBlocksReleaseServicesAsync(vaultType)`, and that call loads the release driver's *own* secrets from the vault during startup. This is a **new startup dependency**: in an environment where those secrets are missing, or the vault is unreachable, or permissions are wrong, **the entire Monitor API will fail to boot** — where today it boots fine. I have no way to provision secrets or verify a deployed environment from here, so this needs a human check per environment. It is also the one thing a hermetic test cannot cover (see H2 below).

The `vaultType` passed in is the value `Program.cs` had already resolved for `ConfigureLogAndSecretsAsync`, deliberately reused so this does not introduce a second, independently-configured vault choice.

## Three ticket details that did not survive contact with the code

**`RegisterBlocksReleaseServicesAsync` is not a no-arg call.** Its real signature is `(IServiceCollection, Blocks.Genesis.VaultType)` and it is async. The ticket's H2 form would not compile. Verified by reflection against the package before planning, not assumed.

**The route as specified would 404.** The ticket asks for `[HttpGet("repos-list")]` *and* the URL `/api/Monitor/repos-list`. Those are incompatible here: `MonitorController` carries a class-level `[Route("[controller]/[action]")]` and all 11 existing actions use a bare `[HttpGet]`, so a relative template combines to `Monitor/GetReposList/repos-list`. The attribute escapes the controller route with `~/` to honour the documented URL, and a test runs the framework's own `AttributeRouteModel.CombineTemplates` — deliberately not asserting the attribute string, since the combination rule is the part worth not trusting to memory. A separate client-side test pins the exact `/api/Monitor/repos-list` the service requests, because the server route test cannot see the `/api` prefix.

**`BaseApiResponse` is ambiguous.** The driver package defines its own. Its namespace is therefore not imported wholesale — only the service interface is aliased in — so every existing `BaseApiResponse` in the controller still means `DomainService.Shared.Models`. On success the driver's response is returned as-is rather than re-mapped, which would risk silently dropping fields from its envelope.

## Cross-tenant safety

The query is keyed `["repos-list", projectKey]` with `enabled: !!projectKey`, even though the request itself takes no parameter. `QueryClient` runs a 60s `staleTime`, so a scope-free key would serve **the previous tenant's repositories** for up to a minute after a tenant switch — and those would then be compared against the *new* tenant's monitor list. The scope exists purely to partition the cache.

## A failed fetch no longer looks like an empty project

`isError` was being discarded, so a 400 or 500 rendered "Select a deployed repo." alongside "No deployed repos available." — indistinguishable from a project that genuinely has no repositories, inviting the user to choose from a list that never loaded. Both messages now distinguish "did not load" from "loaded and empty". This is the client half of C5.

## Known limitation — not introduced here, not fixed here

Switching tenants **with the Add Monitor modal already open** leaves the previously selected repository and its prefilled URL in the form, so submitting can create a monitor in the new tenant pointing at the old tenant's repository. The `values` memo in `use-monitor-form-controller.ts` depends only on `[isEditMode, monitorDetails?.data]`, so nothing reseeds the form when the tenant changes.

I verified this **predates this change and is independent of it** — it reproduces identically with the legacy `useGetEnvRepositories(projectKey)`, because the stale value is form state rather than cached data. It is not fixed here because the fix means altering form-seeding semantics in a memo whose own comment documents a deliberate `defaultValues`/`values` split chosen to avoid flashing the wrong seed on first render — not something to change under a data-source ticket. A test named `KNOWN PRE-EXISTING DEFECT` pins the current behaviour so a future fix has to flip it deliberately, and a follow-up is tracked. **Tenant switching is not end-to-end safe until that lands.**

## Dependency note

Adding `ReleaseDriver.OS` 4.0.1 lifts **Api's** graph to `SeliseBlocks.Genesis.OS` **4.0.5**, while the central declaration stays 4.0.2 and `Worker`/`Alert.DomainService` still resolve 4.0.2. I did **not** raise the central version: that would also upgrade `Worker`, a separate process this ticket does not touch and whose behaviour nobody has assessed against 4.0.5. The split is recorded in `Directory.Packages.props` with the reasoning. Api and Worker are separate processes, and Api's whole graph runs on the single higher version.

## Verification

- **Server:** 341 tests passed, 0 failed (baseline 332, so +9). `dotnet build` 0 errors.
- **Client:** 361 tests passed, 0 failed (baseline 342, so +19). `npm run build` succeeds. Lint 0 errors, 3 warnings — all pre-existing `react-hooks/incompatible-library` on `form.watch()` lines this diff does not touch.
- **Both baselines were fully green before this change**, captured without mutating the working tree, so there is no pre-existing-failure allowance here: any red would be mine.
- **Coverage on added lines**, lcov/cobertura intersected with `git diff -U0` (whole-file numbers are meaningless — these are large existing files): `MonitorController.cs` 31/31, `use-alerts.ts` 3/3, `alerts.service.ts` 2/2, `use-monitor-form-controller.ts` 4/4, `monitor-form-fields.tsx` 1/1 — **100%**. The one exception is stated plainly: `Program.cs`'s registration line is **0%**, because it cannot execute in a hermetic test — it reads the vault. That is precisely why H2 is asserted structurally rather than by resolution.
- **18 mutation probes, 18 killed**: 200-instead-of-400 on driver failure, `[Authorize]` removed, relative route template, `StatusCode` omitted from the 400 body, exception swallowed as 200, cancellation converted to a failure, empty list treated as failure, registration moved after `builder.Build()`, registration reduced to a comment, registration hidden in a string literal, scope-free query key, `enabled` guard dropped, legacy `blocks-logic` hook left in place, `isLoading` not wired from the new hook, prefill order reversed, error branch removed, `isReposError` dropped from the memo deps, and the empty-list note left unguarded.

Two plan reviews and two code reviews, no unresolved critical or major findings.

### Where the tests stop short

**C1 is asserted as authorization metadata, not a live 401.** The test checks that the action carries an authorize requirement and that neither it nor the controller carries `[AllowAnonymous]` — but it does **not** prove authentication middleware is present or correctly ordered. A genuine 401 needs an HTTP boundary, and that is not reachable here: `Program.cs` reads the vault before the builder exists, and the test project has neither `Mvc.Testing` nor `TestHost`. Standing up a hand-assembled host would demonstrate a 401 against a fixture rather than against production startup. Literal C1 remains an integration/environment gap, and the attribute follows the same pattern as all 11 sibling endpoints.

**H2 is asserted structurally** — that `Program.cs` contains the awaited registration ahead of `builder.Build()`, with comments and string literals stripped first so the assertion cannot be satisfied by the call appearing in a comment or a string. Real post-registration resolution belongs in an environment smoke test with provisioned secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
